### PR TITLE
Add TETRA decoding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains a simple PyQt5 application demonstrating how to scan
 frequencies with an SDR (e.g. RTL-SDR, HackRF, LimeSDR) between 380 and 430 MHz.
 The strongest frequency is automatically selected and demodulated to audio
 using external command line tools such as `rtl_power` and `rtl_fm`.
+It now also integrates the osmocom-tetra tools (`receiver1`, `demod_float`,
+`tetra-rx`) to decode unencrypted TETRA control information.
 
 The GUI shows a realtime spectrum, provides start/stop controls, and plays
 received audio through the speakers using PyAudio.
@@ -14,4 +16,5 @@ Run the application with:
 python sdr_gui.py
 ```
 
-External SDR utilities must be installed and accessible in the system path.
+External SDR utilities as well as the osmocom-tetra binaries must be installed
+and accessible in the system path.


### PR DESCRIPTION
## Summary
- add `TetraDecoder` class for osmocom-tetra pipeline
- extend GUI with a new tab for TETRA decoding
- provide start/stop controls and optional auto decode
- display decoder output live in GUI
- update README with new decoding feature

## Testing
- `python -m py_compile sdr_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6878bce2fb0083219aaf4368dfea43c6