### PR TITLE
Implement first-run setup and filtering

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Simple setup script for tetra-decode
+set -e
+sudo apt-get update
+sudo apt-get install -y rtl-sdr osmocom-tetra python3-pip
+pip3 install -r requirements.txt


### PR DESCRIPTION
## Summary
- add SetupWorker to automatically install missing SDR tools and python modules
- log decoder output to rotating log files
- filter decoder output with a regex
- provide a helper `setup.sh` for manual setup

## Testing
- `python -m py_compile sdr_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6878bfb292d48321b4f3cd1f0da5d801