### PR TITLE
Fix initialization order

### DIFF
--- a/sdr_gui.py
+++ b/sdr_gui.py
@@ -451,6 +451,16 @@ class MainWindow(QtWidgets.QMainWindow):
         self.agc_slider.setValue(10000)
         self.agc_value = QtWidgets.QLabel(str(self.agc_slider.value()))
 
+        # configuration needs to be available during tab creation
+        self.config = {
+            "theme": "light",
+            "telegram_token": "",
+            "telegram_chat": "",
+            "scheduler_interval": 15,
+            "scheduler_enabled": False,
+        }
+        self.config.update(load_config())
+
         self.tabs = QtWidgets.QTabWidget()
         self._build_tabs()
 
@@ -462,16 +472,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.scanner = SDRScanner(device=self.device_box.currentText(), parent=self)
         self.player = AudioPlayer(device=self.device_box.currentText(), parent=self)
         self.decoder = TetraDecoder(parent=self)
-
-        # configuration
-        self.config = {
-            "theme": "light",
-            "telegram_token": "",
-            "telegram_chat": "",
-            "scheduler_interval": 15,
-            "scheduler_enabled": False,
-        }
-        self.config.update(load_config())
 
         self.scheduler_timer = QtCore.QTimer(self)
         self.scheduler_timer.timeout.connect(self.run_scheduled_cycle)


### PR DESCRIPTION
## Summary
- fix MainWindow initialization order so configuration is available during tab creation

## Testing
- `python -m py_compile sdr_gui.py`
- `QT_QPA_PLATFORM=offscreen python - <<'EOF'
import sys
from PyQt5 import QtWidgets
import sdr_gui
app = QtWidgets.QApplication(sys.argv)
w = sdr_gui.MainWindow()
print("MainWindow created")
EOF`


------
https://chatgpt.com/codex/tasks/task_e_687ad0790aac832182c870fd796a892e