### PR TITLE
Add Windows setup script and cross-platform fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ Externe SDR-Werkzeuge sowie die osmocom-tetra-Binärdateien müssen installiert 
 - **Setup-Assistent** – Prüft benötigte Tools und Python-Module und installiert sie bei Bedarf.
 - **PPM-Korrektur** – Einstellbarer PPM-Wert für RTL-SDR wird an alle SDR-Werkzeuge übergeben.
 
+## Setup
+
+Unter Linux installierst du alle benötigten Pakete bequem über `setup.sh`:
+
+```bash
+./setup.sh
+```
+
+Auf Windows führst du stattdessen `setup.ps1` in einer PowerShell aus. Die SDR-Treiber sowie die osmocom-tetra Werkzeuge musst du dort separat installieren. Anschließend installierst du die Python-Abhängigkeiten mit:
+
+```powershell
+pip install -r requirements.txt
+```
 ---
 
 # TETRA Decode (English)

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,4 @@
+# PowerShell setup script for tetra-decode
+# Install Python dependencies
+pip install -r requirements.txt
+Write-Host "Please install rtl-sdr drivers and osmocom-tetra tools manually."


### PR DESCRIPTION
## Summary
- add PowerShell `setup.ps1` for Windows users
- document setup steps for Linux and Windows
- adjust SetupWorker to give hints on Windows instead of running apt
- make TetraDecoder fifo creation work on Windows

## Testing
- `python -m py_compile sdr_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_687ae0e33b6c8321bd833d5596de1fd9