### PR TITLE
Add Windows auto install for tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Unter Linux installierst du alle benötigten Pakete bequem über `setup.sh`:
 ./setup.sh
 ```
 
-Auf Windows führst du stattdessen `setup.ps1` in einer PowerShell aus. Die SDR-Treiber sowie die osmocom-tetra Werkzeuge musst du dort separat installieren. Anschließend installierst du die Python-Abhängigkeiten mit:
+Auf Windows führst du stattdessen `setup.ps1` in einer PowerShell aus. Wenn Chocolatey installiert ist, werden die SDR-Treiber und die osmocom-tetra Werkzeuge dabei automatisch eingerichtet. Andernfalls bekommst du einen Hinweis zur manuellen Installation. Anschließend werden die Python-Abhängigkeiten installiert:
 
 ```powershell
 pip install -r requirements.txt

--- a/sdr_gui.py
+++ b/sdr_gui.py
@@ -105,6 +105,12 @@ class SetupWorker(QtCore.QThread):
                 if sys.platform.startswith("linux"):
                     self.log.emit(f"Installing {cmd} via apt ({pkg})")
                     self._run_cmd(["sudo", "apt-get", "install", "-y", pkg])
+                elif sys.platform.startswith("win"):
+                    if shutil.which("choco"):
+                        self.log.emit(f"Installing {cmd} via choco ({pkg})")
+                        self._run_cmd(["choco", "install", "-y", pkg])
+                    else:
+                        self.log.emit(f"{cmd} missing - please install {pkg} manually")
                 else:
                     self.log.emit(f"{cmd} missing - please install {pkg} manually")
 
@@ -112,6 +118,10 @@ class SetupWorker(QtCore.QThread):
             if not self._has_module(mod):
                 self.log.emit(f"Installing python module {mod}")
                 self._run_cmd([sys.executable, "-m", "pip", "install", mod])
+
+        if sys.platform.startswith("win") and shutil.which("choco") and not shutil.which("zadig"):
+            self.log.emit("Installing Zadig via choco")
+            self._run_cmd(["choco", "install", "-y", "zadig"])
 
         setup_file = os.path.expanduser("~/.tetra_setup_done")
         try:

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,4 +1,10 @@
 # PowerShell setup script for tetra-decode
+# Install SDR tools on Windows using Chocolatey when available
+if (Get-Command choco -ErrorAction SilentlyContinue) {
+    choco install -y zadig rtl-sdr osmocom-tetra
+} else {
+    Write-Host "Chocolatey not found. Please install rtl-sdr drivers and osmocom-tetra tools manually or install Chocolatey from https://chocolatey.org/install."
+}
+
 # Install Python dependencies
 pip install -r requirements.txt
-Write-Host "Please install rtl-sdr drivers and osmocom-tetra tools manually."


### PR DESCRIPTION
## Summary
- automate Windows install of rtl-sdr driver and osmocom-tetra via Chocolatey
- support Chocolatey in the setup assistant
- document the automatic setup

## Testing
- `python -m py_compile sdr_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_687ae2c2b70c832193a02a11fa58e4f7