### PR TITLE
Fix Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Unter Linux installierst du alle benötigten Pakete bequem über `setup.sh`:
 ./setup.sh
 ```
 
-Auf Windows führst du stattdessen `setup.ps1` in einer PowerShell aus. Wenn Chocolatey installiert ist, werden die SDR-Treiber und die osmocom-tetra Werkzeuge dabei automatisch eingerichtet. Andernfalls bekommst du einen Hinweis zur manuellen Installation. Anschließend werden die Python-Abhängigkeiten installiert:
+Auf Windows führst du stattdessen `setup.ps1` in einer PowerShell aus. Das Skript installiert nur die Python-Abhängigkeiten und, sofern Chocolatey vorhanden ist, das Treiber-Tool **Zadig**. Die eigentlichen rtl-sdr-Treiber und die osmocom-tetra-Werkzeuge müssen manuell eingerichtet werden, da es dafür keine Chocolatey-Pakete gibt:
 
 ```powershell
 pip install -r requirements.txt

--- a/sdr_gui.py
+++ b/sdr_gui.py
@@ -106,7 +106,9 @@ class SetupWorker(QtCore.QThread):
                     self.log.emit(f"Installing {cmd} via apt ({pkg})")
                     self._run_cmd(["sudo", "apt-get", "install", "-y", pkg])
                 elif sys.platform.startswith("win"):
-                    if shutil.which("choco"):
+                    if pkg in ("rtl-sdr", "osmocom-tetra"):
+                        self.log.emit(f"{cmd} missing - please install {pkg} manually")
+                    elif shutil.which("choco"):
                         self.log.emit(f"Installing {cmd} via choco ({pkg})")
                         self._run_cmd(["choco", "install", "-y", pkg])
                     else:
@@ -122,6 +124,7 @@ class SetupWorker(QtCore.QThread):
         if sys.platform.startswith("win") and shutil.which("choco") and not shutil.which("zadig"):
             self.log.emit("Installing Zadig via choco")
             self._run_cmd(["choco", "install", "-y", "zadig"])
+
 
         setup_file = os.path.expanduser("~/.tetra_setup_done")
         try:

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,10 +1,12 @@
 # PowerShell setup script for tetra-decode
-# Install SDR tools on Windows using Chocolatey when available
+# Install Zadig via Chocolatey when available
 if (Get-Command choco -ErrorAction SilentlyContinue) {
-    choco install -y zadig rtl-sdr osmocom-tetra
+    choco install -y zadig
 } else {
-    Write-Host "Chocolatey not found. Please install rtl-sdr drivers and osmocom-tetra tools manually or install Chocolatey from https://chocolatey.org/install."
+    Write-Host "Chocolatey not found. Please install Zadig manually or install Chocolatey from https://chocolatey.org/install."
 }
+
+Write-Host "Please install rtl-sdr drivers and osmocom-tetra tools manually."
 
 # Install Python dependencies
 pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- clarify that rtl-sdr and osmocom-tetra must be installed manually on Windows
- install only Zadig via Chocolatey
- adjust SetupWorker to avoid nonexistent Chocolatey packages

## Testing
- `python -m py_compile sdr_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_687ae86f705c8321bed3c693865f0364