### PR TITLE
Improve cross-platform setup automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,17 @@ Externe SDR-Werkzeuge sowie die osmocom-tetra-Binärdateien müssen installiert 
 
 ## Setup
 
-Unter Linux installierst du alle benötigten Pakete bequem über `setup.sh`:
+Unter Linux installierst du alle benötigten Pakete bequem über `setup.sh`. Das Skript erkennt automatisch gängige Paketmanager (APT, DNF, Pacman, Zypper), installiert die benötigten Bibliotheken und baut die osmocom-tetra-Werkzeuge bei Bedarf direkt aus den Quellen:
 
 ```bash
 ./setup.sh
 ```
 
-Auf Windows führst du stattdessen `setup.ps1` in einer PowerShell aus. Das Skript installiert nur die Python-Abhängigkeiten und, sofern Chocolatey vorhanden ist, das Treiber-Tool **Zadig**. Die eigentlichen rtl-sdr-Treiber und die osmocom-tetra-Werkzeuge müssen manuell eingerichtet werden, da es dafür keine Chocolatey-Pakete gibt:
+Auf Windows führst du stattdessen `setup.ps1` in einer administrativen PowerShell aus. Das Skript lädt fehlende Abhängigkeiten automatisch herunter, richtet die rtl-sdr-Hilfsprogramme sowie die osmocom-tetra-Binaries in `%ProgramData%\tetra-decode` ein und ergänzt den `PATH`. Chocolatey (wird bei Bedarf installiert) sorgt zusätzlich für Werkzeuge wie **Zadig** und SoX. Sollten einzelne Download-Quellen temporär nicht erreichbar sein, weist dich das Skript darauf hin und bietet die Möglichkeit zur manuellen Nachinstallation:
 
 ```powershell
-pip install -r requirements.txt
+Set-ExecutionPolicy Bypass -Scope Process -Force
+.\setup.ps1
 ```
 ---
 
@@ -60,6 +61,21 @@ python sdr_gui.py
 ```
 
 External SDR utilities as well as the osmocom-tetra binaries must be installed and accessible in the system path.
+
+## Setup
+
+On Linux you can run `setup.sh`. The helper detects common package managers (APT, DNF, Pacman, Zypper), installs all required development headers and, if necessary, builds the osmocom-tetra suite from source before pulling the Python dependencies:
+
+```bash
+./setup.sh
+```
+
+On Windows launch `setup.ps1` from an elevated PowerShell session. It bootstraps Chocolatey when required, downloads rtl-sdr utilities and the osmocom-tetra binaries into `%ProgramData%\tetra-decode`, amends the `PATH` accordingly and finally installs the Python packages. If any upstream download mirrors are temporarily unavailable the script reports the issue so you can provide the files manually:
+
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force
+.\setup.ps1
+```
 
 ## Features
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,12 +1,198 @@
-# PowerShell setup script for tetra-decode
-# Install Zadig via Chocolatey when available
-if (Get-Command choco -ErrorAction SilentlyContinue) {
-    choco install -y zadig
-} else {
-    Write-Host "Chocolatey not found. Please install Zadig manually or install Chocolatey from https://chocolatey.org/install."
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+function Assert-Administrator {
+    $currentUser = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+    if (-not $currentUser.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        throw "Bitte starte dieses Skript in einer administrativen PowerShell." }
 }
 
-Write-Host "Please install rtl-sdr drivers and osmocom-tetra tools manually."
+function Ensure-Chocolatey {
+    if (Get-Command choco -ErrorAction SilentlyContinue) {
+        return
+    }
 
-# Install Python dependencies
-pip install -r requirements.txt
+    Write-Host "Chocolatey nicht gefunden. Installiere Chocolatey..."
+    Set-ExecutionPolicy Bypass -Scope Process -Force
+    $installScript = Invoke-WebRequest -UseBasicParsing "https://community.chocolatey.org/install.ps1"
+    Invoke-Expression $installScript.Content
+}
+
+function Install-ChocoPackage {
+    param(
+        [Parameter(Mandatory)] [string] $Name
+    )
+
+    if (-not (Get-Command choco -ErrorAction SilentlyContinue)) { return }
+    $alreadyInstalled = choco list --local-only --exact $Name | Select-String "^$Name " -Quiet
+    if ($alreadyInstalled) {
+        return
+    }
+    choco install -y $Name
+}
+
+function Test-ZipFile {
+    param([string] $Path)
+    try {
+        [System.IO.Compression.ZipFile]::OpenRead($Path).Dispose()
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+function Download-Archive {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [string[]] $Urls
+    )
+
+    $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) (([System.IO.Path]::GetRandomFileName()) + '.zip')
+    foreach ($url in $Urls) {
+        try {
+            Write-Host "Lade $Name von $url ..."
+            Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $tempFile
+            if (Test-ZipFile -Path $tempFile) {
+                Write-Host "$Name erfolgreich heruntergeladen."
+                return $tempFile
+            } else {
+                Write-Warning "Die heruntergeladene Datei von $url war kein gültiges ZIP-Archiv."
+                Remove-Item -ErrorAction SilentlyContinue $tempFile
+            }
+        } catch {
+            Write-Warning "Download von $url fehlgeschlagen: $_"
+            Remove-Item -ErrorAction SilentlyContinue $tempFile
+        }
+    }
+    Remove-Item -ErrorAction SilentlyContinue $tempFile
+    throw "Konnte $Name nicht herunterladen. Bitte manuell installieren."
+}
+
+function Ensure-Directory {
+    param([string] $Path)
+    if (-not (Test-Path $Path)) {
+        New-Item -ItemType Directory -Force -Path $Path | Out-Null
+    }
+}
+
+function Add-ToPath {
+    param([string] $Directory)
+    $machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+    if (-not $machinePath) { $machinePath = '' }
+    $paths = $machinePath.Split(';') | Where-Object { $_ }
+    if ($paths -contains $Directory) { return }
+    $newPath = ($paths + $Directory) -join ';'
+    [Environment]::SetEnvironmentVariable('Path', $newPath, 'Machine')
+    if (-not ($env:Path.Split(';') -contains $Directory)) {
+        $env:Path = $env:Path + ';' + $Directory
+    }
+}
+
+function Install-ToolArchive {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [string[]] $Urls,
+        [Parameter(Mandatory)] [string] $TargetDirectory,
+        [Parameter(Mandatory)] [string[]] $BinaryNames
+    )
+
+    $existing = $true
+    foreach ($binary in $BinaryNames) {
+        if (-not (Get-Command $binary -ErrorAction SilentlyContinue)) {
+            $existing = $false
+            break
+        }
+    }
+    if ($existing -and (Test-Path $TargetDirectory)) {
+        Write-Host "$Name ist bereits installiert."
+        Add-ToPath $TargetDirectory
+        return
+    }
+
+    $archive = Download-Archive -Name $Name -Urls $Urls
+    $parent = Split-Path $TargetDirectory -Parent
+    Ensure-Directory $parent
+    if (Test-Path $TargetDirectory) {
+        Remove-Item -Recurse -Force $TargetDirectory
+    }
+
+    $tempExtract = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+    Ensure-Directory $tempExtract
+    Expand-Archive -Path $archive -DestinationPath $tempExtract -Force
+
+    $payload = Get-ChildItem -Path $tempExtract
+    $payloadPath = $tempExtract
+    if ($payload.Count -eq 1 -and $payload[0].PSIsContainer) {
+        $payloadPath = $payload[0].FullName
+    }
+
+    Ensure-Directory $TargetDirectory
+    Get-ChildItem -Path $payloadPath | ForEach-Object {
+        Move-Item -Path $_.FullName -Destination $TargetDirectory -Force
+    }
+
+    Remove-Item -Recurse -Force $tempExtract
+    Remove-Item $archive -Force
+
+    $binaryDirectories = @()
+    foreach ($binary in $BinaryNames) {
+        $resolved = Get-ChildItem -Path $TargetDirectory -Filter $binary -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($null -eq $resolved) {
+            throw "$Name wurde entpackt, aber $binary konnte nicht gefunden werden."
+        }
+        $binaryDirectories += $resolved.DirectoryName
+    }
+
+    $binaryDirectories | Sort-Object -Unique | ForEach-Object { Add-ToPath $_ }
+}
+
+function Install-PythonRequirements {
+    param([string] $ProjectRoot)
+    if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+        throw "Python 3 wurde nicht gefunden. Bitte installiere Python 3 und starte das Skript erneut."
+    }
+    python -m pip install --upgrade pip
+    python -m pip install -r (Join-Path $ProjectRoot 'requirements.txt')
+}
+
+Assert-Administrator
+
+$projectRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$installRoot = Join-Path ${env:ProgramData} 'tetra-decode'
+Ensure-Directory $installRoot
+
+Ensure-Chocolatey
+Install-ChocoPackage -Name zadig
+Install-ChocoPackage -Name sox
+
+$toolTargets = @(
+    @{ Name = 'RTL-SDR Werkzeuge';
+       Urls = @(
+           'https://downloads.osmocom.org/binaries/windows/rtl-sdr/rtl-sdr-release.zip',
+           'https://github.com/librtlsdr/rtl-sdr/releases/latest/download/rtl-sdr-win64.zip'
+       );
+       Target = Join-Path $installRoot 'rtl-sdr';
+       Binaries = @('rtl_fm.exe','rtl_power.exe','rtl_test.exe') },
+    @{ Name = 'osmocom-tetra Werkzeuge';
+       Urls = @(
+           'https://www.osmocom.org/attachments/download/3446/osmo-tetra-win64-20200512.zip',
+           'https://gitlab.com/varosi/osmo-tetra-win64/-/raw/master/osmo-tetra-win64.zip?inline=false'
+       );
+       Target = Join-Path $installRoot 'osmocom-tetra';
+       Binaries = @('receiver1.exe','tetra-rx.exe','demod_float.exe') }
+)
+
+foreach ($tool in $toolTargets) {
+    try {
+        Install-ToolArchive -Name $tool.Name -Urls $tool.Urls -TargetDirectory $tool.Target -BinaryNames $tool.Binaries
+    } catch {
+        Write-Warning $_
+    }
+}
+
+Install-PythonRequirements -ProjectRoot $projectRoot
+
+Write-Host "Setup abgeschlossen. Stelle sicher, dass du die PowerShell neu startest, damit PATH-Änderungen aktiv werden."

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,129 @@
-#!/bin/bash
-# Simple setup script for tetra-decode
-set -e
-sudo apt-get update
-sudo apt-get install -y rtl-sdr osmocom-tetra python3-pip
-pip3 install -r requirements.txt
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_PREFIX="/usr/local"
+BUILD_DIR="${PROJECT_ROOT}/.build/osmo-tetra"
+
+log() {
+    printf '\n[%s] %s\n' "$(date '+%H:%M:%S')" "$*"
+}
+
+die() {
+    printf 'Error: %s\n' "$*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "Benötigtes Programm '$1' wurde nicht gefunden."
+}
+
+run_sudo() {
+    if [[ "${EUID}" -ne 0 ]]; then
+        sudo "$@"
+    else
+        "$@"
+    fi
+}
+
+install_packages() {
+    local manager=""
+    if command -v apt-get >/dev/null 2>&1; then
+        manager="apt"
+    elif command -v dnf >/dev/null 2>&1; then
+        manager="dnf"
+    elif command -v pacman >/dev/null 2>&1; then
+        manager="pacman"
+    elif command -v zypper >/dev/null 2>&1; then
+        manager="zypper"
+    fi
+
+    case "$manager" in
+        apt)
+            log "Verwende apt, um Systemabhängigkeiten zu installieren."
+            run_sudo apt-get update
+            run_sudo apt-get install -y \
+                build-essential pkg-config cmake ninja-build git wget curl \
+                autoconf automake libtool \
+                libfftw3-dev libitpp-dev libusb-1.0-0-dev libpcsclite-dev \
+                libgnutls28-dev libboost-all-dev libgmp-dev liborc-0.4-dev \
+                rtl-sdr sox
+            # osmocom-Abhängigkeiten
+            run_sudo apt-get install -y libosmocore-dev libosmo-dsp-dev || \
+                log "libosmocore-dev nicht verfügbar. Wird bei Bedarf aus den Quellen gebaut."
+            ;;
+        dnf)
+            log "Verwende dnf, um Systemabhängigkeiten zu installieren."
+            run_sudo dnf install -y \
+                @"Development Tools" @"C Development Tools and Libraries" \
+                git wget curl cmake ninja-build autoconf automake libtool \
+                fftw-devel itpp-devel \
+                libusbx-devel pcsclite-devel gnutls-devel boost-devel gmp-devel orc-devel \
+                rtl-sdr sox || true
+            ;;
+        pacman)
+            log "Verwende pacman, um Systemabhängigkeiten zu installieren."
+            run_sudo pacman -Sy --noconfirm --needed \
+                base-devel git wget curl cmake ninja autoconf automake libtool \
+                fftw libusb pcsclite gnutls boost-libs gmp orc sox rtl-sdr || true
+            ;;
+        zypper)
+            log "Verwende zypper, um Systemabhängigkeiten zu installieren."
+            run_sudo zypper refresh
+            run_sudo zypper install -y \
+                -t pattern devel_C_C++ git wget curl cmake ninja autoconf automake libtool fftw3-devel itpp-devel libusb-1_0-devel pcsclite-devel \
+                libgnutls-devel libboost_headers-devel libgmp-devel orc-devel rtl-sdr sox || true
+            ;;
+        *)
+            log "Kein unterstützter Paketmanager gefunden. Überspringe Systempakete."
+            ;;
+    esac
+}
+
+build_osmo_tetra() {
+    if command -v receiver1 >/dev/null 2>&1 && command -v tetra-rx >/dev/null 2>&1; then
+        log "osmocom-tetra scheint bereits installiert zu sein."
+        return
+    fi
+
+    require_command git
+
+    mkdir -p "${BUILD_DIR}"
+    if [[ ! -d "${BUILD_DIR}/osmo-tetra" ]]; then
+        log "Klone osmocom/osmo-tetra..."
+        git clone --depth 1 https://gitea.osmocom.org/sdr/osmo-tetra.git "${BUILD_DIR}/osmo-tetra"
+    else
+        log "Aktualisiere vorhandenes osmo-tetra Repository..."
+        (cd "${BUILD_DIR}/osmo-tetra" && git pull --ff-only)
+    fi
+
+    pushd "${BUILD_DIR}/osmo-tetra" >/dev/null
+    log "Führe Autotools-Konfiguration für osmo-tetra aus..."
+    if [[ ! -f configure ]]; then
+        ./autogen.sh
+    fi
+
+    log "Starte Build von osmo-tetra..."
+    ./configure --prefix="${INSTALL_PREFIX}"
+    make -j"$(nproc)"
+    run_sudo make install
+    run_sudo ldconfig || true
+    popd >/dev/null
+}
+
+install_python_packages() {
+    log "Installiere Python-Abhängigkeiten..."
+    require_command python3
+    python3 -m pip install --upgrade pip
+    python3 -m pip install -r "${PROJECT_ROOT}/requirements.txt"
+}
+
+main() {
+    log "Starte Setup für tetra-decode (Linux)."
+    install_packages
+    build_osmo_tetra
+    install_python_packages
+    log "Setup abgeschlossen."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- extend the Linux setup script to detect package managers, install development libraries, and build osmocom-tetra from source when needed
- add a Windows setup routine that bootstraps Chocolatey, downloads rtl-sdr/osmocom tool archives, and updates PATH entries automatically
- document the new installation workflows for both platforms in the README

## Testing
- python -m compileall sdr_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68d7ec0375e08321b32d282ad175c275