### PR TITLE
install.ps1: osmo‑tetra auf vorgefertigtes Windows‑Archiv umstellen

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -244,17 +244,13 @@ $toolTargets = @(
        Binaries = @('rtl_fm.exe','rtl_power.exe','rtl_test.exe') },
     @{ Name = 'osmocom-tetra Werkzeuge';
        Urls = @(
-           'https://github.com/sq5bpf/osmo-tetra-sq5bpf/archive/4e9f1b23b460a6b24270ece685ac68d4d7fd4cc8.zip',
-           'https://codeload.github.com/sq5bpf/osmo-tetra-sq5bpf/zip/4e9f1b23b460a6b24270ece685ac68d4d7fd4cc8'
+           'https://osmocom.org/attachments/download/3446/osmo-tetra-win64-20200512.zip',
+           'https://archive.org/download/osmo-tetra-win64-20200512/osmo-tetra-win64-20200512.zip',
+           'https://downloads.osmocom.org/attachments/download/3446/osmo-tetra-win64-20200512.zip'
        );
-       Checksums = @{
-           'https://github.com/sq5bpf/osmo-tetra-sq5bpf/archive/4e9f1b23b460a6b24270ece685ac68d4d7fd4cc8.zip' = '38920f7f49fa887e3bc98dd3d801e1574ad7143b43666e3671ea20ec9a26518e';
-           'https://codeload.github.com/sq5bpf/osmo-tetra-sq5bpf/zip/4e9f1b23b460a6b24270ece685ac68d4d7fd4cc8' = '38920f7f49fa887e3bc98dd3d801e1574ad7143b43666e3671ea20ec9a26518e'
-       };
        ManualSteps = @(
-           'Lade die Windows-Binaries oder den Quellcode von der OsmocomTETRA-Wiki-Seite: https://osmocom.org/projects/tetra/wiki/OsmocomTETRA',
-           'Entpacke das Archiv nach ' + (Join-Path $installRoot 'osmocom-tetra'),
-           'Falls es sich um Quellcode handelt: Baue die Tools (receiver1.exe, tetra-rx.exe, demod_float.exe) und kopiere sie in das Zielverzeichnis.',
+           'Lade das Windows-Binary-Archiv von der OsmocomTETRA-Wiki-Seite: https://osmocom.org/projects/tetra/wiki/OsmocomTETRA',
+           'Entpacke das Archiv nach ' + (Join-Path $installRoot 'osmocom-tetra') + ' und stelle sicher, dass die Tools (receiver1.exe, tetra-rx.exe, demod_float.exe) enthalten sind.',
            'Stelle sicher, dass das Zielverzeichnis im PATH liegt.'
        );
        Target = Join-Path $installRoot 'osmocom-tetra';


### PR DESCRIPTION
### Motivation
- Sicherstellen, dass `Install-ToolArchive` die erwarteten `.exe`-Binaries zuverlässig findet, indem statt Quellcode ein vorgefertigtes Windows-Archiv verwendet wird.
- Manuelle Hinweise vereinfachen und die gleichen ZIP-Quellen wie in `setup.ps1` verwenden, um Konsistenz zwischen Installationsskripten zu erreichen.

### Description
- Ersetzt die osmo‑tetra Download‑URLs in `install.ps1` durch die vorgefertigten Windows‑Archive `osmo-tetra-win64-20200512.zip` (Mirrors bei `osmocom`, `archive.org` und `downloads.osmocom`).
- Entfernt die vorherige Checksum‑Definition für das Quellarchiv und passt die `ManualSteps` an, sodass direkt das Windows‑Binary‑Archiv entpackt und die enthaltenen Tools (`receiver1.exe`, `tetra-rx.exe`, `demod_float.exe`) geprüft werden.
- Verhalten von `Install-ToolArchive` und die erwarteten Binary‑Namen bleiben erhalten, sodass nach dem Entpacken die `.exe`-Dateien gesucht und die jeweiligen Verzeichnisse dem `PATH` hinzugefügt werden.

### Testing
- Versuch, die PowerShell‑Syntax mit dem Befehl `pwsh -Command "[System.Management.Automation.Language.Parser]::ParseFile('install.ps1',[ref]$null,[ref]$errors) | Out-Null; if ($errors) { $errors | ForEach-Object { Write-Error $_ } ; exit 1 }"` zu prüfen, schlug fehl, weil `pwsh` in der aktuellen Umgebung nicht verfügbar ist.
- In dieser Umgebung konnten keine weiteren automatisierten Tests ausgeführt werden.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833cbafb7883218a66b5e94bf59f28)