### PR TITLE
Build-Abhängigkeiten für Python-Installationen ergänzen

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -282,11 +282,26 @@ install_python_requirements() {
     if command -v python3 >/dev/null 2>&1; then
         log "Installiere Python-Abhängigkeiten..."
         if ensure_package_manager; then
+            log "Installiere Build-Abhängigkeiten für Python-Pakete..."
+            case "${PKG_MANAGER}" in
+                apt)
+                    install_system_packages build-essential python3-dev portaudio19-dev
+                    ;;
+                dnf)
+                    install_system_packages gcc gcc-c++ make python3-devel portaudio-devel || true
+                    ;;
+                pacman)
+                    install_system_packages base-devel python portaudio || true
+                    ;;
+                zypper)
+                    install_system_packages gcc gcc-c++ make python3-devel portaudio-devel || true
+                    ;;
+            esac
             log "Installiere Laufzeitbibliotheken für PyQt5 (glib/gthread)..."
             case "${PKG_MANAGER}" in
                 apt)
                     install_system_packages libglib2.0-0
-                    ;;
+                ;;
                 dnf)
                     install_system_packages glib2 || true
                     ;;


### PR DESCRIPTION
### Motivation
- Sicherstellen, dass notwendige Compiler/Header und PortAudio-Dev-Pakete vor `pip`-Installationen vorhanden sind, auch wenn `build_osmo_tetra` übersprungen wird.

### Description
- Ergänzt in `install.sh` innerhalb von `install_python_requirements()` die Installation von Build-Abhängigkeiten für die Paketmanager `apt`, `dnf`, `pacman` und `zypper`.
- Installierte Pakete umfassen unter anderem `build-essential`, `python3-dev`, `portaudio19-dev` bzw. plattformspezifische Äquivalente wie `gcc`, `python3-devel`, `portaudio-devel` oder `base-devel`.
- Diese Schritte werden vor den bereits vorhandenen Laufzeit- und Audio-Dev-Installationen ausgeführt, damit Python-Erweiterungen bei `pip install -r requirements.txt` kompiliert werden können.
- Betroffene Datei: `install.sh` (Erweiterung der Paket-Installations-Case-Abschnitte).

### Testing
- Syntaxprüfung der geänderten Shell-Skripte mit `bash -n install.sh` wurde ausgeführt und ergab keinen Fehler.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833dca2e3483219e36ea42399a3497)