### PR TITLE
Live-PCM-Stream fuer TETRA-Audio vorbereiten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ dist/
 
 *.spec
 tools/osmocom-tetra/
+tools/tetra-codec/
 installer_payload/gnuradio/
 dist-installer/TETRA-Decode-Windows-Offline-Setup.exe*

--- a/README.md
+++ b/README.md
@@ -150,12 +150,24 @@ Er installiert alle benötigten Zusatzkomponenten lokal mit, damit die Anwendung
 direkt nach der Installation startbereit ist. `setup.ps1` und `install.ps1`
 bleiben nur als Entwickler-/Fallback-Skripte erhalten.
 
+Für Live-Audio aus unverschlüsselten TETRA-Sprachkanälen gibt es zusätzlich
+ein WSL-Backend. Es baut ein gepatchtes `tetra-rx`, lädt den ETSI-TETRA-Codec
+und installiert `cdecoder`/`sdecoder` lokal unter `tools/tetra-codec`, ohne
+dauerhaft Audiodateien zu schreiben:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\ensure_tetra_audio_backend.ps1
+```
+
+Die GUI nutzt dieses Backend automatisch, wenn „Decoder-Audio“ aktiv ist.
+Verschlüsselte TETRA-Kanäle werden erkannt und bleiben stumm.
+
 ## Funktionen
 
 - **Frequenzscan** – nutzt `rtl_power`, um einen wählbaren Bereich abzusuchen. Das stärkste Signal wird automatisch für die weitere Verarbeitung ausgewählt.
 - **Echtzeit-Spektrum** – das Spektrum wird während des Scans kontinuierlich dargestellt.
 - **Audio-Demodulation** – `rtl_fm` demoduliert die gewählte Frequenz, PyAudio spielt das Audio ab. Eine anpassbare AGC hält die Lautstärke stabil.
-- **TETRA-Dekodierung** – integriert `receiver1`, `demod_float` oder `float_to_bits` sowie `tetra-rx`, um unverschlüsselte Kontrollkanäle zu dekodieren. Die Ausgabe erscheint in einem eigenen Tab und kann per Regex gefiltert werden.
+- **TETRA-Dekodierung** – integriert `receiver1`, `demod_float` oder `float_to_bits` sowie `tetra-rx`, um Kontrollkanäle, Netzinfos und Sprechgruppen zu dekodieren. Mit gebautem Audio-Backend werden unverschlüsselte Sprach-Bursts live als PCM wiedergegeben.
 - **Aktivitätserkennung** – Audio-Pegelüberwachung zeigt Aktivität an und kann optional Telegram-Benachrichtigungen senden. Erkannte Aktivität wird als WAV aufgezeichnet.
 - **Zellinformationen** – dekodierte Cell-IDs, LAC, MCC/MNC und die genutzte Frequenz werden in einer Tabelle gespeichert und können als CSV exportiert werden.
 - **Paketstatistiken** – zeigt ein Balkendiagramm der empfangenen TETRA-Pakettypen.

--- a/WINDOWS_INSTALLER.md
+++ b/WINDOWS_INSTALLER.md
@@ -7,6 +7,7 @@ Das Windows-Komplettpaket wird mit Inno Setup gebaut und liegt nach einem erfolg
 - `tetra-decode.exe`: per PyInstaller gebaute GUI mit den Python-Abhängigkeiten aus `requirements.txt`.
 - RTL-SDR-Werkzeuge: `rtl_sdr.exe`, `rtl_fm.exe`, `rtl_power.exe`, `rtl_test.exe` und benötigte Laufzeitbibliotheken.
 - Osmocom-TETRA: `tetra-rx.exe`, `float_to_bits.exe`, MSYS2-Laufzeitbibliotheken und das offizielle `simdemod3.py` aus `third_party/osmo-tetra`.
+- TETRA-Audio-Backend: Skripte und lokale Patches für den WSL-Build von audiofähigem `tetra-rx` sowie ETSI-Codec `cdecoder`/`sdecoder`.
 - Zadig: Treiberwerkzeug für WinUSB/libusb-Geräte.
 - GNU Radio/Radioconda: wird als großer Installer-Payload eingebettet und während der Installation lokal installiert. Dadurch ist kein winget-, Chocolatey- oder Internet-Zugriff auf dem Zielsystem nötig.
 

--- a/installer.iss
+++ b/installer.iss
@@ -56,6 +56,7 @@ Source: "requirements.txt"; DestDir: "{app}"; Flags: ignoreversion
 Source: "setup.ps1"; DestDir: "{app}"; Flags: ignoreversion
 Source: "install.ps1"; DestDir: "{app}"; Flags: ignoreversion
 Source: "scripts\*"; DestDir: "{app}\scripts"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "patches\*"; DestDir: "{app}\patches"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist
 Source: "third_party\osmo-tetra\*"; DestDir: "{app}\third_party\osmo-tetra"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist
 Source: "installer_payload\rtl-sdr\x64\*"; DestDir: "{commonappdata}\tetra-decode\rtl-sdr\x64"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "installer_payload\osmocom-tetra\*"; DestDir: "{commonappdata}\tetra-decode\osmocom-tetra"; Flags: ignoreversion recursesubdirs createallsubdirs

--- a/patches/osmo-tetra/audio_udp_backend.patch
+++ b/patches/osmo-tetra/audio_udp_backend.patch
@@ -1,0 +1,176 @@
+diff --git a/src/lower_mac/tetra_lower_mac.c b/src/lower_mac/tetra_lower_mac.c
+index d58f2ab..c563c64 100644
+--- a/src/lower_mac/tetra_lower_mac.c
++++ b/src/lower_mac/tetra_lower_mac.c
+@@ -24,6 +24,9 @@
+ #include <unistd.h>
+ #include <errno.h>
+ #include <linux/limits.h>
++#include <sys/socket.h>
++#include <netinet/in.h>
++#include <arpa/inet.h>
+ 
+ #include <osmocom/core/utils.h>
+ #include <osmocom/core/msgb.h>
+@@ -112,6 +115,102 @@ struct tetra_cell_data {
+ 
+ static struct tetra_cell_data _tcd, *tcd = &_tcd;
+ 
++static int audio_udp_socket = -2;
++static struct sockaddr_in audio_udp_addr;
++static int audio_udp_rxid = 1;
++static int audio_udp_debug = 0;
++static int audio_udp_sent = 0;
++
++static void audio_udp_init(void)
++{
++	const char *port_text;
++	const char *host_text;
++	const char *rxid_text;
++	int port;
++
++	if (audio_udp_socket != -2)
++		return;
++
++	audio_udp_socket = -1;
++	audio_udp_debug = getenv("TETRA_AUDIO_DEBUG") ? 1 : 0;
++	port_text = getenv("TETRA_AUDIO_UDP_PORT");
++	if (!port_text || !*port_text) {
++		if (audio_udp_debug)
++			fprintf(stderr, "TETRA audio UDP disabled: TETRA_AUDIO_UDP_PORT fehlt\n");
++		return;
++	}
++
++	port = atoi(port_text);
++	if (port <= 0 || port > 65535) {
++		if (audio_udp_debug)
++			fprintf(stderr, "TETRA audio UDP disabled: ungültiger Port %d\n", port);
++		return;
++	}
++
++	host_text = getenv("TETRA_AUDIO_UDP_HOST");
++	if (!host_text || !*host_text)
++		host_text = "127.0.0.1";
++
++	rxid_text = getenv("TETRA_AUDIO_RXID");
++	if (rxid_text && *rxid_text)
++		audio_udp_rxid = atoi(rxid_text);
++
++	memset(&audio_udp_addr, 0, sizeof(audio_udp_addr));
++	audio_udp_addr.sin_family = AF_INET;
++	audio_udp_addr.sin_port = htons(port);
++	if (!inet_aton(host_text, &audio_udp_addr.sin_addr)) {
++		if (audio_udp_debug)
++			fprintf(stderr, "TETRA audio UDP disabled: ungültiger Host %s\n", host_text);
++		return;
++	}
++
++	audio_udp_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
++	if (audio_udp_socket < 0)
++		audio_udp_socket = -1;
++	if (audio_udp_debug)
++		fprintf(stderr, "TETRA audio UDP %s %s:%d RX:%d\n",
++			audio_udp_socket >= 0 ? "aktiv" : "fehler", host_text, port, audio_udp_rxid);
++}
++
++static void audio_udp_send_traffic(int usage, const int16_t *block)
++{
++	uint8_t packet[13 + sizeof(int16_t) * 690];
++
++	audio_udp_init();
++	if (audio_udp_socket < 0)
++		return;
++
++	memset(packet, 0, sizeof(packet));
++	snprintf((char *)packet, 13, "TRA:%2.2x RX:%2.2x", usage & 0xff, audio_udp_rxid & 0xff);
++	memcpy(packet + 13, block, sizeof(int16_t) * 690);
++	sendto(audio_udp_socket, packet, sizeof(packet), 0,
++		(struct sockaddr *)&audio_udp_addr, sizeof(audio_udp_addr));
++	if (audio_udp_debug && audio_udp_sent < 5)
++		fprintf(stderr, "TETRA audio UDP send usage=%d bytes=%zu\n", usage, sizeof(packet));
++	audio_udp_sent++;
++}
++
++static void build_traffic_audio_block(const uint8_t *type4, int16_t *block)
++{
++	int i;
++
++	memset(block, 0x00, sizeof(int16_t) * 690);
++	for (i = 0; i < 6; i++)
++		block[115*i] = 0x6b21 + i;
++
++	for (i = 0; i < 114; i++)
++		block[1+i] = type4[i] ? -127 : 127;
++
++	for (i = 0; i < 114; i++)
++		block[116+i] = type4[114+i] ? -127 : 127;
++
++	for (i = 0; i < 114; i++)
++		block[231+i] = type4[228+i] ? -127 : 127;
++
++	for (i = 0; i < 90; i++)
++		block[346+i] = type4[342+i] ? -127 : 127;
++}
++
+ int is_bsch(struct tetra_tdma_time *tm)
+ {
+ 	if (tm->fn == 18 && tm->tn == 4 - ((tm->mn+1)%4))
+@@ -194,17 +293,21 @@ void tp_sap_udata_ind(enum tp_sap_data_type type, int blk_num, const uint8_t *bi
+ 	if (tms->cur_burst.is_traffic && type == TPSAP_T_NDB && blk_num == BLK_1)
+ 		tms->cur_burst.blk1_stolen = true;
+ 
+-	/* If this is a traffic channel and we have a dump output directory, dump. */
+-	if (tms->dumpdir &&
+-	    tms->cur_burst.is_traffic &&
++	/* If this is a traffic channel, optionally stream audio and dump debug data. */
++	if (tms->cur_burst.is_traffic &&
+ 	    (type == TPSAP_T_SCH_F || (blk_num == BLK_2 && !tms->cur_burst.blk2_stolen))) {
+ 
+ 		char fname[PATH_MAX];
+ 		int16_t block[690];
+ 		FILE *f;
+-		int i;
+ 
+-		/* Open target file */
++		/* Generate a block */
++		build_traffic_audio_block(type4, block);
++		audio_udp_send_traffic(tms->cur_burst.is_traffic, block);
++
++		if (!tms->dumpdir)
++			goto traffic_stream_done;
++
+ 		snprintf(fname, sizeof(fname), "%s/traffic_%d_%d.out", tms->dumpdir,
+ 			tms->cur_burst.is_traffic, tms->tsn);
+ 		f = fopen(fname, "ab");
+@@ -213,23 +316,6 @@ void tp_sap_udata_ind(enum tp_sap_data_type type, int blk_num, const uint8_t *bi
+ 			exit(1);
+ 		}
+ 
+-		/* Generate a block */
+-		memset(block, 0x00, sizeof(int16_t) * 690);
+-		for (i = 0; i < 6; i++)
+-			block[115*i] = 0x6b21 + i;
+-
+-		for (i = 0; i < 114; i++)
+-			block[1+i] = type4[i] ? -127 : 127;
+-
+-		for (i = 0; i < 114; i++)
+-			block[116+i] = type4[114+i] ? -127 : 127;
+-
+-		for (i = 0; i < 114; i++)
+-			block[231+i] = type4[228+i] ? -127 : 127;
+-
+-		for (i = 0; i < 90; i++)
+-			block[346+i] = type4[342+i] ? -127 : 127;
+-
+ 		/* Write it */
+ 		fwrite(block, sizeof(int16_t), 690, f);
+ 		fclose(f);
+@@ -242,6 +328,7 @@ void tp_sap_udata_ind(enum tp_sap_data_type type, int blk_num, const uint8_t *bi
+ 		fclose(f);
+ 		goto out;
+ 	}
++traffic_stream_done:
+ 
+ 	if (tbp->interleave_a) {
+ 		/* Run block deinterleaving: type-3 bits */

--- a/scripts/ensure_osmocom_tetra.sh
+++ b/scripts/ensure_osmocom_tetra.sh
@@ -33,8 +33,23 @@ check_build_requirements() {
     pkg-config --exists libosmocore || die "libosmocore-dev fehlt."
 }
 
+apply_local_patches() {
+    local patch_file="${PROJECT_ROOT}/patches/osmo-tetra/audio_udp_backend.patch"
+    local target_file="${OSMO_SOURCE_DIR}/src/lower_mac/tetra_lower_mac.c"
+    [[ -f "${patch_file}" ]] || return
+    if grep -q "TETRA_AUDIO_UDP_PORT" "${target_file}"; then
+        return
+    fi
+
+    log "Aktiviere lokalen Audio-Burst-Ausgang für tetra-rx..."
+    (
+        cd "${OSMO_SOURCE_DIR}"
+        patch -p1 < "${patch_file}"
+    )
+}
+
 build_and_install() {
-    log "Baue offizielle Osmocom-TETRA Werkzeuge aus ${OSMO_SOURCE_DIR}..."
+    log "Baue Osmocom-TETRA-Werkzeuge aus ${OSMO_SOURCE_DIR}..."
     make -C "${OSMO_SOURCE_DIR}/src"
 
     mkdir -p "${OSMO_TOOL_DIR}"
@@ -55,13 +70,16 @@ warn_optional_runtime() {
         return
     fi
     if ! python3 -c 'import gnuradio' >/dev/null 2>&1; then
-        log "Warnung: GNU Radio Python-Modul fehlt; installiere gnuradio fuer Live-Demodulation."
+        log "Warnung: GNU Radio Python-Modul fehlt; installiere GNU Radio für Live-Demodulation."
     fi
 }
 
 ensure_submodule
 check_build_requirements
+apply_local_patches
 build_and_install
 warn_optional_runtime
 
 log "Fertig. Toolpfad: ${OSMO_TOOL_DIR}"
+
+# © 2026 Erik Schauer, do1ffe@darc.de

--- a/scripts/ensure_tetra_audio_backend.ps1
+++ b/scripts/ensure_tetra_audio_backend.ps1
@@ -1,0 +1,30 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$wsl = Get-Command wsl.exe -ErrorAction SilentlyContinue
+if (-not $wsl) {
+    throw 'WSL wird für das lokale TETRA-Audio-Backend benötigt.'
+}
+
+function Convert-ToWslPath {
+    param([Parameter(Mandatory = $true)][string] $Path)
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    if ($fullPath -match '^([A-Za-z]):\\(.*)$') {
+        $drive = $Matches[1].ToLowerInvariant()
+        $rest = $Matches[2] -replace '\\', '/'
+        return "/mnt/$drive/$rest"
+    }
+    throw "Pfad kann nicht nach WSL umgerechnet werden: $fullPath"
+}
+
+$wslProjectRoot = Convert-ToWslPath -Path $ProjectRoot
+$quotedRoot = $wslProjectRoot.Replace("'", "'\''")
+& wsl.exe -- bash -lc "cd '$quotedRoot' && chmod +x scripts/ensure_tetra_audio_backend.sh && scripts/ensure_tetra_audio_backend.sh"
+if ($LASTEXITCODE -ne 0) {
+    throw 'Der Build des TETRA-Audio-Backends ist fehlgeschlagen.'
+}
+
+# © 2026 Erik Schauer, do1ffe@darc.de

--- a/scripts/ensure_tetra_audio_backend.sh
+++ b/scripts/ensure_tetra_audio_backend.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CODEC_URL="https://www.etsi.org/deliver/etsi_en/300300_300399/30039502/01.03.01_60/en_30039502v010301p0.zip"
+CODEC_MD5="a8115fe68ef8f8cc466f4192572a1e3e"
+PATCH_DIR="${PROJECT_ROOT}/third_party/osmo-tetra/etsi_codec-patches"
+BUILD_DIR="${PROJECT_ROOT}/.build/tetra-codec"
+ARCHIV="${BUILD_DIR}/$(basename "${CODEC_URL}")"
+QUELLORDNER="${BUILD_DIR}/quelle"
+CODEC_TOOL_DIR="${PROJECT_ROOT}/tools/tetra-codec/bin"
+
+log() {
+    printf '[TETRA-Audio] %s\n' "$*"
+}
+
+die() {
+    printf '[TETRA-Audio] Fehler: %s\n' "$*" >&2
+    exit 1
+}
+
+pruefe_werkzeuge() {
+    command -v python3 >/dev/null 2>&1 || die "python3 fehlt."
+    command -v make >/dev/null 2>&1 || die "make fehlt."
+    command -v gcc >/dev/null 2>&1 || die "gcc fehlt."
+    command -v patch >/dev/null 2>&1 || die "patch fehlt."
+    command -v md5sum >/dev/null 2>&1 || die "md5sum fehlt."
+    command -v curl >/dev/null 2>&1 || command -v wget >/dev/null 2>&1 || die "curl oder wget fehlt."
+}
+
+lade_codec() {
+    mkdir -p "${BUILD_DIR}"
+    if [[ -f "${ARCHIV}" ]]; then
+        if [[ "$(md5sum "${ARCHIV}" | awk '{print $1}')" == "${CODEC_MD5}" ]]; then
+            log "Codec-Archiv ist bereits vorhanden."
+            return
+        fi
+        log "Verwerfe unvollständiges Codec-Archiv."
+        rm -f "${ARCHIV}"
+    fi
+
+    if command -v curl >/dev/null 2>&1; then
+        log "Lade ETSI-TETRA-Codec..."
+        curl -L --fail -A "Mozilla/5.0" --output "${ARCHIV}" "${CODEC_URL}"
+    else
+        log "Lade ETSI-TETRA-Codec..."
+        wget --user-agent="Mozilla/5.0" -O "${ARCHIV}" "${CODEC_URL}"
+    fi
+
+    local ist_md5
+    ist_md5="$(md5sum "${ARCHIV}" | awk '{print $1}')"
+    [[ "${ist_md5}" == "${CODEC_MD5}" ]] || die "Codec-Prüfsumme stimmt nicht (${ist_md5})."
+}
+
+entpacke_codec_kleingeschrieben() {
+    rm -rf "${QUELLORDNER}"
+    mkdir -p "${QUELLORDNER}"
+    python3 - "${ARCHIV}" "${QUELLORDNER}" <<'PY'
+import pathlib
+import sys
+import zipfile
+
+archiv = pathlib.Path(sys.argv[1])
+ziel = pathlib.Path(sys.argv[2])
+for info in zipfile.ZipFile(archiv).infolist():
+    name = info.filename.lower()
+    if not name or name.endswith("/"):
+        continue
+    pfad = ziel / name
+    pfad.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archiv).open(info) as src, pfad.open("wb") as dst:
+        dst.write(src.read())
+PY
+}
+
+patch_codec() {
+    log "Patch für ETSI-Codec anwenden..."
+    (
+        cd "${QUELLORDNER}"
+        while IFS= read -r patchdatei; do
+            patchdatei="${patchdatei%$'\r'}"
+            [[ -z "${patchdatei}" ]] && continue
+            patch -p1 -N -E < "${PATCH_DIR}/${patchdatei}"
+        done < "${PATCH_DIR}/series"
+    )
+}
+
+patch_codec_streaming() {
+    log "Live-Flush für Codec-Pipes aktivieren..."
+    python3 - "${QUELLORDNER}" <<'PY'
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+
+sdecoder = root / "c-code" / "sdecoder.c"
+text = sdecoder.read_text(encoding="latin-1")
+alt = "    fwrite(synth, sizeof(Word16), L_frame,  f_syn);   /* Write output file */"
+neu = alt + "\n    fflush(f_syn);"
+if "fflush(f_syn);" not in text:
+    text = text.replace(alt, neu)
+sdecoder.write_text(text, encoding="latin-1")
+
+cdecoder = root / "c-code" / "cdecoder.c"
+text = cdecoder.read_text(encoding="latin-1")
+alt = """\t\tif( fwrite( Reordered_array+137, sizeof(short), 137, fout ) \n\t\t\t\t\t!= 137 ) {\n\t\t\tfputs(\"cdecoder: can't write to output_file\",stderr );\n\t\t\tbreak;\n\t\t}"""
+neu = alt + "\n\t\tfflush(fout);"
+if "fflush(fout);" not in text:
+    text = text.replace(alt, neu)
+cdecoder.write_text(text, encoding="latin-1")
+PY
+}
+
+baue_codec() {
+    log "Baue cdecoder und sdecoder..."
+    make -C "${QUELLORDNER}/c-code"
+    mkdir -p "${CODEC_TOOL_DIR}"
+    install -m 0755 "${QUELLORDNER}/c-code/cdecoder" "${CODEC_TOOL_DIR}/cdecoder"
+    install -m 0755 "${QUELLORDNER}/c-code/sdecoder" "${CODEC_TOOL_DIR}/sdecoder"
+}
+
+baue_osmocom() {
+    log "Baue TETRA-Decoder mit Audio-Burst-Ausgang..."
+    bash "${PROJECT_ROOT}/scripts/ensure_osmocom_tetra.sh"
+}
+
+pruefe_backend() {
+    [[ -x "${CODEC_TOOL_DIR}/cdecoder" ]] || die "cdecoder wurde nicht gebaut."
+    [[ -x "${CODEC_TOOL_DIR}/sdecoder" ]] || die "sdecoder wurde nicht gebaut."
+    [[ -x "${PROJECT_ROOT}/tools/osmocom-tetra/bin/tetra-rx" ]] || die "tetra-rx wurde nicht gebaut."
+    log "Fertig. Codec: ${CODEC_TOOL_DIR}, Decoder: ${PROJECT_ROOT}/tools/osmocom-tetra/bin"
+}
+
+pruefe_werkzeuge
+baue_osmocom
+if [[ ! -x "${CODEC_TOOL_DIR}/cdecoder" || ! -x "${CODEC_TOOL_DIR}/sdecoder" ]]; then
+    lade_codec
+    entpacke_codec_kleingeschrieben
+    patch_codec
+    patch_codec_streaming
+    baue_codec
+else
+    log "Codec-Werkzeuge sind bereits gebaut."
+fi
+pruefe_backend
+
+# © 2026 Erik Schauer, do1ffe@darc.de

--- a/scripts/tetra_audio_backend_wsl.py
+++ b/scripts/tetra_audio_backend_wsl.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Wandelt Telive-kompatible TETRA-Traffic-Bursts live in PCM um."""
+
+import argparse
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+
+FRAME_PREFIX = 13
+TRAFFIC_BYTES = 1380
+MIN_FRAME_BYTES = FRAME_PREFIX + TRAFFIC_BYTES
+PCM_CHUNK_BYTES = 320
+
+
+def _status(text: str) -> None:
+    print(f"[TETRA-Audio] {text}", file=sys.stderr, flush=True)
+
+
+def _decoder_befehl(programm: str) -> list[str]:
+    if shutil.which("stdbuf"):
+        return ["stdbuf", "-o0", "-e0", programm, "/dev/stdin", "/dev/stdout"]
+    return [programm, "/dev/stdin", "/dev/stdout"]
+
+
+def _starte_codec(cdecoder: str, sdecoder: str):
+    cproc = subprocess.Popen(
+        _decoder_befehl(cdecoder),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    sproc = subprocess.Popen(
+        _decoder_befehl(sdecoder),
+        stdin=cproc.stdout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if cproc.stdout:
+        cproc.stdout.close()
+    return cproc, sproc
+
+
+def _verwerfe_stderr(proc: subprocess.Popen) -> None:
+    stream = proc.stderr
+    if not stream:
+        return
+    try:
+        for _chunk in iter(lambda: stream.read(4096), b""):
+            pass
+    except Exception:
+        pass
+
+
+def _pcm_weiterreichen(proc: subprocess.Popen, stopp: threading.Event) -> None:
+    stream = proc.stdout
+    if not stream:
+        return
+    ausgabe = sys.stdout.buffer
+    while not stopp.is_set():
+        try:
+            daten = stream.read(PCM_CHUNK_BYTES)
+        except Exception:
+            break
+        if not daten:
+            if proc.poll() is not None:
+                break
+            time.sleep(0.02)
+            continue
+        try:
+            ausgabe.write(daten)
+            ausgabe.flush()
+        except BrokenPipeError:
+            stopp.set()
+            break
+
+
+def _beende(proc: subprocess.Popen | None) -> None:
+    if not proc or proc.poll() is not None:
+        return
+    try:
+        proc.terminate()
+        proc.wait(timeout=1.5)
+    except Exception:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Live-Backend für unverschlüsselte TETRA-Sprachframes."
+    )
+    parser.add_argument("--udp-host", default="127.0.0.1")
+    parser.add_argument("--udp-port", type=int, required=True)
+    parser.add_argument("--cdecoder", default=os.environ.get("TETRA_CDECODER", "cdecoder"))
+    parser.add_argument("--sdecoder", default=os.environ.get("TETRA_SDECODER", "sdecoder"))
+    args = parser.parse_args()
+
+    stopp = threading.Event()
+
+    def _signal_handler(_signum, _frame):
+        stopp.set()
+
+    signal.signal(signal.SIGTERM, _signal_handler)
+    signal.signal(signal.SIGINT, _signal_handler)
+
+    cproc = sproc = None
+    sock = None
+    try:
+        cproc, sproc = _starte_codec(args.cdecoder, args.sdecoder)
+        for proc in (cproc, sproc):
+            threading.Thread(target=_verwerfe_stderr, args=(proc,), daemon=True).start()
+        threading.Thread(target=_pcm_weiterreichen, args=(sproc, stopp), daemon=True).start()
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind((args.udp_host, args.udp_port))
+        sock.settimeout(0.25)
+        _status(f"hört auf UDP {args.udp_host}:{args.udp_port}")
+
+        while not stopp.is_set():
+            if cproc.poll() is not None or sproc.poll() is not None:
+                _status("Codec-Prozess wurde beendet")
+                return 3
+            try:
+                paket, _addr = sock.recvfrom(2048)
+            except socket.timeout:
+                continue
+            if len(paket) < MIN_FRAME_BYTES or not paket.startswith(b"TRA:"):
+                continue
+            if not cproc.stdin:
+                continue
+            try:
+                cproc.stdin.write(paket[FRAME_PREFIX:FRAME_PREFIX + TRAFFIC_BYTES])
+                cproc.stdin.flush()
+            except BrokenPipeError:
+                _status("Codec-Pipe wurde geschlossen")
+                return 4
+        return 0
+    except Exception as exc:
+        _status(f"Fehler: {exc}")
+        return 2
+    finally:
+        stopp.set()
+        if sock:
+            try:
+                sock.close()
+            except OSError:
+                pass
+        if cproc and cproc.stdin:
+            try:
+                cproc.stdin.close()
+            except Exception:
+                pass
+        _beende(sproc)
+        _beende(cproc)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+# © 2026 Erik Schauer, do1ffe@darc.de

--- a/sdr_gui.py
+++ b/sdr_gui.py
@@ -489,6 +489,10 @@ TETRA_SCAN_BIN_HZ = 12_500
 TETRA_CHANNEL_RASTER_HZ = 12_500
 
 
+class RtlSdrStreamError(RuntimeError):
+    """Signalisiert, dass RTL-SDR zwar startet, aber keine IQ-Daten liefert."""
+
+
 def _terminate_process_list(procs):
     for proc in procs:
         if proc and proc.poll() is None:
@@ -506,6 +510,19 @@ def _terminate_process_list(procs):
                 proc.kill()
             except Exception:
                 pass
+
+
+def _kurzer_prozessfehler(stderr_data) -> str:
+    if not stderr_data:
+        return ""
+    if isinstance(stderr_data, bytes):
+        text = stderr_data.decode("utf-8", errors="replace")
+    else:
+        text = str(stderr_data)
+    zeilen = [zeile.strip() for zeile in text.splitlines() if zeile.strip()]
+    if not zeilen:
+        return ""
+    return " Details: " + " | ".join(zeilen[-5:])
 
 
 def _tetra_line_indicates_encryption(line: str) -> bool:
@@ -987,13 +1004,15 @@ def _capture_rtl_sdr_iq(
         cmd.extend(["-d", str(device_id)])
     cmd.append("-")
     proc = None
-    timeout_seconds = max(8.0, float(seconds) + 8.0)
+    timeout_seconds = max(3.0, float(seconds) + 3.0)
     deadline = time.time() + timeout_seconds
+    raw = b""
+    stderr_data = b""
     try:
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             **_hidden_subprocess_kwargs(),
         )
         if proc_callback:
@@ -1005,23 +1024,32 @@ def _capture_rtl_sdr_iq(
                 raise RuntimeError("rtl_sdr-Aufnahme abgebrochen.")
             remaining = max(0.05, min(0.25, deadline - time.time()))
             try:
-                raw, _ = proc.communicate(timeout=remaining)
+                raw, stderr_data = proc.communicate(timeout=remaining)
                 break
-            except subprocess.TimeoutExpired:
+            except subprocess.TimeoutExpired as exc:
                 if time.time() >= deadline:
                     _terminate_process_list([proc])
-                    raise RuntimeError(
-                        f"rtl_sdr-Aufnahme fehlgeschlagen: Timeout nach "
-                        f"{timeout_seconds:.1f} Sekunden."
+                    try:
+                        raw, stderr_data = proc.communicate(timeout=1)
+                    except Exception:
+                        raw = exc.output or b""
+                        stderr_data = exc.stderr or b""
+                    raise RtlSdrStreamError(
+                        "rtl_sdr liefert keine IQ-Daten "
+                        f"(Timeout nach {timeout_seconds:.1f} Sekunden)."
+                        + _kurzer_prozessfehler(stderr_data)
                     )
-    except RuntimeError:
+    except RtlSdrStreamError:
         raise
     except Exception as exc:
         if proc and proc.poll() is None:
             _terminate_process_list([proc])
         raise RuntimeError(f"rtl_sdr-Aufnahme fehlgeschlagen: {exc}") from exc
     if len(raw) < 4096:
-        raise RuntimeError(f"rtl_sdr lieferte zu wenige IQ-Daten ({len(raw)} Byte).")
+        raise RtlSdrStreamError(
+            f"rtl_sdr lieferte zu wenige IQ-Daten ({len(raw)} Byte)."
+            + _kurzer_prozessfehler(stderr_data)
+        )
     return raw
 
 
@@ -1957,6 +1985,7 @@ class CalibrationWorker(QtCore.QThread):
     """Berechnet PPM und RF-Gain anhand eines bekannten Referenzsignals."""
 
     log = QtCore.pyqtSignal(str)
+    error = QtCore.pyqtSignal(str)
     ppm_ready = QtCore.pyqtSignal(dict)
     gain_ready = QtCore.pyqtSignal(dict)
 
@@ -1980,6 +2009,7 @@ class CalibrationWorker(QtCore.QThread):
         self._running = threading.Event()
         self._procs = []
         self._proc_lock = threading.RLock()
+        self._stream_error = None
 
     def stop(self):
         self._running.clear()
@@ -1997,9 +2027,10 @@ class CalibrationWorker(QtCore.QThread):
 
     def run(self):
         self._running.set()
+        self._stream_error = None
         try:
             if not shutil.which("rtl_sdr"):
-                self.log.emit("rtl_sdr nicht gefunden; Kalibrierung nicht möglich.")
+                self.error.emit("rtl_sdr nicht gefunden; Kalibrierung nicht möglich.")
                 return
 
             gain_for_ppm = self.gain
@@ -2014,11 +2045,21 @@ class CalibrationWorker(QtCore.QThread):
                     self.gain_ready.emit(gain_result)
 
             if self.mode in ("ppm", "both") and self._running.is_set():
+                if self._stream_error:
+                    self.log.emit(
+                        "PPM-Kalibrierung übersprungen, weil der RTL-SDR keine "
+                        "IQ-Daten liefert."
+                    )
+                    return
                 try:
                     self._auto_ppm(gain_for_ppm)
+                except RtlSdrStreamError as exc:
+                    if self._running.is_set():
+                        self._stream_error = str(exc)
+                        self.error.emit(self._rtl_stream_error_text(exc))
                 except Exception as exc:
                     if self._running.is_set():
-                        self.log.emit(f"PPM-Kalibrierung fehlgeschlagen: {exc}")
+                        self.error.emit(f"PPM-Kalibrierung fehlgeschlagen: {exc}")
         finally:
             self._running.clear()
             self._terminate_processes()
@@ -2059,7 +2100,7 @@ class CalibrationWorker(QtCore.QThread):
             gains = [gains[int(index)] for index in indices]
 
         self.log.emit(
-            f"RF-Gain-Automatik auf {self.reference_hz/1e6:.4f} MHz testet "
+            f"RF-Gain-Automatik auf {self.reference_hz/1e6:.4f} MHz testet bis zu "
             f"{len(gains)} Stufen..."
         )
         best = None
@@ -2079,6 +2120,10 @@ class CalibrationWorker(QtCore.QThread):
                     stop_event=self._running,
                     proc_callback=self._add_proc,
                 )
+            except RtlSdrStreamError as exc:
+                self._stream_error = str(exc)
+                self.error.emit(self._rtl_stream_error_text(exc))
+                return None
             except Exception as exc:
                 self.log.emit(f"Gain {gain:.1f} dB konnte nicht gemessen werden: {exc}")
                 continue
@@ -2107,6 +2152,15 @@ class CalibrationWorker(QtCore.QThread):
 
     def _tune_offset_hz(self):
         return min(250_000.0, max(50_000.0, float(self.search_span_hz) * 1.5))
+
+    @staticmethod
+    def _rtl_stream_error_text(exc):
+        return (
+            "RTL-SDR liefert keine IQ-Daten. Kalibrierung abgebrochen. "
+            "Bitte Stick kurz abziehen/einstecken, USB-Port wechseln und mit Zadig "
+            "WinUSB für Bulk-In Interface 0 prüfen. "
+            f"Technik: {exc}"
+        )
 
 
 class SDRScanner(QtCore.QObject):
@@ -3594,6 +3648,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._signal_search_rows = {}
         self._overview_signal_rows = {}
         self.calibration_worker = None
+        self._calibration_failed = False
         self._closing = False
         self.monitoring_active = False
         self.monitor_timer = QtCore.QTimer(self)
@@ -4949,6 +5004,7 @@ class MainWindow(QtWidgets.QMainWindow):
         name, device_id = self._current_device_info()
         reference_hz = float(self.ref_freq_spin.value()) * 1e6
         search_span_hz = float(self.cal_span_spin.value()) * 1e3
+        self._calibration_failed = False
         self.calibration_status_label.setText("Kalibrierung läuft...")
         self._refresh_dashboard_status()
         self.log.appendPlainText(
@@ -4965,6 +5021,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         worker.log.connect(self.log.appendPlainText)
         worker.log.connect(logger.info)
+        worker.error.connect(self._calibration_error)
         worker.ppm_ready.connect(self._apply_ppm_calibration)
         worker.gain_ready.connect(self._apply_gain_calibration)
         worker.finished.connect(self._calibration_finished)
@@ -4986,6 +5043,16 @@ class MainWindow(QtWidgets.QMainWindow):
                     pass
                 worker.terminate()
                 worker.wait(3000)
+
+    @QtCore.pyqtSlot(str)
+    def _calibration_error(self, text: str):
+        if self._closing:
+            return
+        self._calibration_failed = True
+        self.calibration_status_label.setText(text)
+        self.log.appendPlainText(text)
+        logger.info(text)
+        self._refresh_dashboard_status()
 
     @QtCore.pyqtSlot(dict)
     def _apply_ppm_calibration(self, result: dict):
@@ -5040,6 +5107,10 @@ class MainWindow(QtWidgets.QMainWindow):
     def _calibration_finished(self):
         if self._closing:
             self.calibration_worker = None
+            return
+        if self._calibration_failed:
+            self.calibration_worker = None
+            self._refresh_dashboard_status()
             return
         if self.calibration_status_label.text() == "Kalibrierung läuft...":
             self.calibration_status_label.setText("Kalibrierung beendet.")

--- a/sdr_gui.py
+++ b/sdr_gui.py
@@ -2794,41 +2794,62 @@ class DecodedAudioPlayer(QtCore.QObject):
         self._wav = None
 
     def start(self, record: bool = False):
-        self.stop()
-        self.record = record
-        if self._pa is None:
-            self._pa = pyaudio.PyAudio()
-        self._stream = self._pa.open(
-            format=pyaudio.paInt16,
-            channels=1,
-            rate=8000,
-            output=True,
-            frames_per_buffer=1024,
-        )
-        if record:
-            path = os.path.expanduser("~/TetraVoice")
-            os.makedirs(path, exist_ok=True)
-            name = datetime.now().strftime("voice_%Y%m%d_%H%M%S.wav")
-            self._wav = wave.open(os.path.join(path, name), "wb")
-            self._wav.setnchannels(1)
-            self._wav.setsampwidth(2)
-            self._wav.setframerate(8000)
+        try:
+            self.stop()
+            self.record = record
+            if self._pa is None:
+                self._pa = pyaudio.PyAudio()
+            self._stream = self._pa.open(
+                format=pyaudio.paInt16,
+                channels=1,
+                rate=8000,
+                output=True,
+                frames_per_buffer=1024,
+            )
+            if record:
+                path = os.path.expanduser("~/TetraVoice")
+                os.makedirs(path, exist_ok=True)
+                name = datetime.now().strftime("voice_%Y%m%d_%H%M%S.wav")
+                self._wav = wave.open(os.path.join(path, name), "wb")
+                self._wav.setnchannels(1)
+                self._wav.setsampwidth(2)
+                self._wav.setframerate(8000)
+            return True
+        except Exception as exc:
+            logger.warning("Dekodierte Audiowiedergabe konnte nicht starten: %s", exc)
+            self.stop()
+            return False
 
     def stop(self):
         if self._stream:
-            self._stream.stop_stream()
-            self._stream.close()
+            try:
+                self._stream.stop_stream()
+            except Exception:
+                pass
+            try:
+                self._stream.close()
+            except Exception:
+                pass
             self._stream = None
         if self._wav:
-            self._wav.close()
+            try:
+                self._wav.close()
+            except Exception:
+                pass
             self._wav = None
 
     def process(self, data: bytes):
         if not self._stream:
-            return
-        self._stream.write(data)
-        if self._wav:
-            self._wav.writeframes(data)
+            return False
+        try:
+            self._stream.write(data)
+            if self._wav:
+                self._wav.writeframes(data)
+            return True
+        except Exception as exc:
+            logger.warning("Dekodierte Audiowiedergabe wurde gestoppt: %s", exc)
+            self.stop()
+            return False
 
 
 class PcmAudioStreamClient(QtCore.QObject):
@@ -3496,6 +3517,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.dec_audio_player = DecodedAudioPlayer(parent=self)
         self.stream_audio_player = DecodedAudioPlayer(parent=self)
         self.audio_stream_client = PcmAudioStreamClient(parent=self)
+        self._stream_record_requested = False
 
         self.scheduler_timer = QtCore.QTimer(self)
         self.scheduler_timer.timeout.connect(self.run_scheduled_cycle)
@@ -3889,10 +3911,17 @@ class MainWindow(QtWidgets.QMainWindow):
         audio_index = self.audio_mode_combo.findData(audio_mode)
         self.audio_mode_combo.setCurrentIndex(audio_index if audio_index >= 0 else 0)
         audio_bar.addWidget(self.audio_mode_combo)
-        self.play_audio_cb = QtWidgets.QCheckBox("Audio aktiv")
+        self.play_audio_cb = QtWidgets.QCheckBox("Decoder-Audio")
+        self.play_audio_cb.setToolTip(
+            "Aktiviert Audio aus einer audiofähigen Decoder-Kette. "
+            "Der Live-Stream wird separat gestartet."
+        )
         self.play_audio_cb.setChecked(self.audio_mode_combo.currentData() != "off")
         audio_bar.addWidget(self.play_audio_cb)
-        self.record_audio_cb = QtWidgets.QCheckBox("als WAV speichern")
+        self.record_audio_cb = QtWidgets.QCheckBox("WAV speichern")
+        self.record_audio_cb.setToolTip(
+            "Schreibt nur dann WAV-Dateien, wenn dieser Haken bewusst gesetzt ist."
+        )
         self.record_audio_cb.setChecked(bool(self.config.get("record_audio", False)))
         audio_bar.addWidget(self.record_audio_cb)
         audio_bar.addStretch()
@@ -3925,6 +3954,7 @@ class MainWindow(QtWidgets.QMainWindow):
             "PCM 16 Bit, mono, 8000 Hz, ohne Mitschnitt"
         )
         self.audio_stream_status_label.setObjectName("statusDetail")
+        self.audio_stream_status_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
         stream_bar.addWidget(self.audio_stream_status_label)
         stream_bar.addStretch()
         audio_data_layout.addLayout(stream_bar)
@@ -4511,12 +4541,14 @@ class MainWindow(QtWidgets.QMainWindow):
         host, port = self._audio_stream_endpoint()
         self.config["audio_stream_host"] = host
         self.config["audio_stream_port"] = int(port)
-        record = bool(self.record_audio_cb.isChecked())
-        self.stream_audio_player.start(record=record)
+        self._stream_record_requested = bool(self.record_audio_cb.isChecked())
+        self.stream_audio_player.stop()
         self.audio_stream_start_btn.setEnabled(False)
         self.audio_stream_stop_btn.setEnabled(True)
         self.audio_stream_status_label.setText(f"Verbinde {host}:{port}")
+        self.audio_stream_status_label.setToolTip(f"Verbinde {host}:{port}")
         self.audio_status_label.setText("Audio-Status: Stream verbindet")
+        self.audio_status_label.setToolTip(f"Verbinde {host}:{port}")
         self.audio_stream_client.start(host, port)
         self._refresh_dashboard_status()
 
@@ -4541,11 +4573,34 @@ class MainWindow(QtWidgets.QMainWindow):
 
     @QtCore.pyqtSlot(str)
     def _stream_status(self, text: str):
+        kurz, detail = self._format_stream_status(text)
+        if text.startswith("Stream verbunden"):
+            if not self.stream_audio_player.start(record=self._stream_record_requested):
+                kurz = "Audiogerät nicht verfügbar"
+                detail = "Der Stream ist verbunden, aber der Audioausgang konnte nicht geöffnet werden."
         if hasattr(self, "audio_stream_status_label"):
-            self.audio_stream_status_label.setText(text)
+            self.audio_stream_status_label.setText(kurz)
+            self.audio_stream_status_label.setToolTip(detail)
         if hasattr(self, "audio_status_label"):
-            self.audio_status_label.setText(f"Audio-Status: {text}")
+            self.audio_status_label.setText(f"Audio-Status: {kurz}")
+            self.audio_status_label.setToolTip(detail)
         self._refresh_dashboard_status()
+
+    def _format_stream_status(self, text: str):
+        host, port = self._audio_stream_endpoint()
+        detail = text
+        lower = text.lower()
+        if "nicht verbunden" in lower:
+            if "10061" in text or "connection refused" in lower or "verweigert" in lower:
+                return f"Kein Audio-Backend auf {host}:{port}", detail
+            return f"Stream nicht verbunden ({host}:{port})", detail
+        if text.startswith("Stream verbunden"):
+            return f"Stream verbunden ({host}:{port})", detail
+        if text.startswith("Stream verbindet"):
+            return f"Stream verbindet ({host}:{port})", detail
+        if text.startswith("Stream beendet"):
+            return "Stream beendet", detail
+        return text, detail
 
     @QtCore.pyqtSlot(float)
     def _stream_level(self, level: float):
@@ -4966,11 +5021,13 @@ class MainWindow(QtWidgets.QMainWindow):
         audio_mode = self._audio_mode()
         audio_requested = audio_mode != "off" and self.play_audio_cb.isChecked()
         if audio_requested and self.decoder.audio_output_supported():
-            self.dec_audio_player.start(record=rec)
-            if audio_mode == "always":
-                self.audio_status_label.setText("Audio-Status: Wiedergabe aktiv")
+            if self.dec_audio_player.start(record=rec):
+                if audio_mode == "always":
+                    self.audio_status_label.setText("Audio-Status: Wiedergabe aktiv")
+                else:
+                    self.audio_status_label.setText("Audio-Status: wartet auf unverschlüsselte Sprache")
             else:
-                self.audio_status_label.setText("Audio-Status: wartet auf unverschlüsselte Sprache")
+                self.audio_status_label.setText("Audio-Status: Audiogerät nicht verfügbar")
         elif audio_requested:
             self.audio_status_label.setText(
                 "Audio-Status: keine audiofähige Decoder-Kette verfügbar"

--- a/sdr_gui.py
+++ b/sdr_gui.py
@@ -627,6 +627,8 @@ def _classify_tetra_lines(lines, bits_size=0):
 
 
 def _decoder_line_type(line: str):
+    if line.startswith("Audiohinweis:"):
+        return "Audio"
     if re.search(r"CRC COMP:\s*0x[0-9A-Fa-f]+\s+OK\b", line):
         return "CRC OK"
     if "CRC COMP:" in line:
@@ -658,9 +660,16 @@ def _decoder_line_for_ui(line: str) -> bool:
         return False
     if text.startswith("Audioausgabe:"):
         return True
+    if text.startswith("Audiohinweis:"):
+        return True
     if text.startswith(("Keine ", "Zu wenige ", "Windows-TETRA-", "Nutze ")):
         return True
     if "BNCH SYSINFO" in text or "SYSINFO PDU" in text:
+        return True
+    if re.search(
+        r"^(?:Advanced link|Air encryption|Voice service|SNDCP data|Circuit data):",
+        text,
+    ):
         return True
     if "ACCESS-ASSIGN PDU" in text and "Traffic" in text:
         return True
@@ -675,6 +684,29 @@ def _decoder_line_for_ui(line: str) -> bool:
     if extract_talkgroup_ids(text):
         return True
     return False
+
+
+def _wichtige_decoder_zeilen(lines, limit: int = 120):
+    wichtige = []
+    for line in lines:
+        if _decoder_line_for_ui(line):
+            wichtige.append(line)
+            if len(wichtige) >= limit:
+                break
+    return wichtige
+
+
+def _audio_hinweis_aus_tetra_zeilen(lines, bits_size=0):
+    info = _classify_tetra_lines(lines, bits_size)
+    audio = str(info.get("audio", ""))
+    if audio in ("unverschlüsselt, Backend fehlt", "unverschlüsselt", "Audio möglich"):
+        return (
+            "Audiohinweis: unverschlüsselte TETRA-Sprache ist signalisiert, "
+            "aber die aktuelle Windows-Pipeline liefert kein PCM-Audio."
+        )
+    if audio == "verschlüsselt":
+        return "Audiohinweis: TETRA-Sprache ist verschlüsselt; Audioausgabe bleibt aus."
+    return ""
 
 
 def _extract_sysinfo(line: str):
@@ -3160,6 +3192,9 @@ class TetraDecoder(QtCore.QObject):
         self._audio_thread = None
         self._audio_path = None
         self._audio_mode = None
+        self.tune_frequency_hz = None
+        self.iq_mode = "normal"
+        self.xlate_hz = 0.0
 
     def audio_output_supported(self):
         return _legacy_audio_decoder_available()
@@ -3215,11 +3250,12 @@ class TetraDecoder(QtCore.QObject):
         self._procs = []
 
     def _rtl_sdr_cmd(self, frequency: float):
+        tune_frequency = self.tune_frequency_hz or frequency
         cmd = [
             "rtl_sdr",
             "-p", str(self.ppm),
             "-g", str(_resolve_gain_value(self.gain)),
-            "-f", str(int(frequency)),
+            "-f", str(int(tune_frequency)),
             "-s", "2000000",
         ]
         if self.device_id is not None:
@@ -3284,8 +3320,13 @@ class TetraDecoder(QtCore.QObject):
             "Audioausgabe: mit der aktuellen Windows-Osmocom-Pipeline nicht verfügbar; "
             "Steuerdaten, Netzinfos und Sprechgruppen/Adressen werden dekodiert."
         )
-        batch_seconds = 10
-        while self._running.is_set():
+        batch_seconds = 8
+        max_ui_lines = 45
+        max_blocks = 3
+        block_count = 0
+        letzter_audio_hinweis = None
+        while self._running.is_set() and block_count < max_blocks:
+            block_count += 1
             bits_path = None
             try:
                 tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".bits")
@@ -3293,9 +3334,11 @@ class TetraDecoder(QtCore.QObject):
                 tmp.close()
 
                 with open(bits_path, "wb") as bits_out:
+                    conv_env = _gnuradio_env_for(gnuradio_python)
+                    conv_env["TETRA_IQ_MODE"] = str(self.iq_mode or "normal")
                     channelizer_env = _gnuradio_env_for(gnuradio_python)
                     channelizer_env.update({
-                        "TETRA_XLATE_HZ": "0",
+                        "TETRA_XLATE_HZ": str(float(self.xlate_hz or 0.0)),
                         "TETRA_LOW_PASS": "12500",
                         "TETRA_TRANSITION": "2500",
                         "TETRA_OUT_RATE": "36000",
@@ -3312,6 +3355,7 @@ class TetraDecoder(QtCore.QObject):
                         stdin=p1.stdout,
                         stdout=subprocess.PIPE,
                         stderr=subprocess.DEVNULL,
+                        env=conv_env,
                         **_hidden_subprocess_kwargs(),
                     )
                     self._procs.append(pconv)
@@ -3361,28 +3405,55 @@ class TetraDecoder(QtCore.QObject):
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     bufsize=1,
                     **_hidden_subprocess_kwargs(),
                 )
                 self._procs.append(p3)
-                dekodiert = False
-                if p3.stdout:
-                    for line in p3.stdout:
-                        if not self._running.is_set():
-                            break
-                        txt = line.rstrip()
-                        if not txt or txt == "EOF":
-                            continue
-                        dekodiert = True
-                        self.output.emit(txt)
-                        if _tetra_line_indicates_encryption(txt):
-                            self.encrypted.emit()
                 try:
-                    p3.wait(timeout=5)
-                except Exception:
-                    pass
+                    out, _ = p3.communicate(timeout=max(8, batch_seconds + 5))
+                except subprocess.TimeoutExpired:
+                    self.output.emit(
+                        "Decoderblock wurde begrenzt, damit die Oberfläche bedienbar bleibt."
+                    )
+                    self._terminate_processes()
+                    try:
+                        out, _ = p3.communicate(timeout=2)
+                    except Exception:
+                        out = ""
                 finally:
                     self._terminate_processes()
+
+                lines = [
+                    line.strip()
+                    for line in (out or "").splitlines()
+                    if line.strip() and line.strip() != "EOF"
+                ]
+                dekodiert = bool(lines)
+                if any(_tetra_line_indicates_encryption(line) for line in lines):
+                    self.encrypted.emit()
+
+                audio_hinweis = _audio_hinweis_aus_tetra_zeilen(lines, bits_size)
+                if audio_hinweis and audio_hinweis != letzter_audio_hinweis:
+                    self.output.emit(audio_hinweis)
+                    letzter_audio_hinweis = audio_hinweis
+
+                sichtbare_zeilen = _wichtige_decoder_zeilen(lines, limit=max_ui_lines)
+                for txt in sichtbare_zeilen:
+                    if not self._running.is_set():
+                        break
+                    self.output.emit(txt)
+                if dekodiert and not sichtbare_zeilen:
+                    self.output.emit(
+                        "TETRA-Daten empfangen; Rohdaten ohne neue Netz-, "
+                        "Sprechgruppen- oder Audioinfos wurden ausgeblendet."
+                    )
+                elif len(sichtbare_zeilen) >= max_ui_lines:
+                    self.output.emit(
+                        "Weitere Decoderzeilen in diesem Block wurden ausgeblendet, "
+                        "damit die Oberfläche reaktionsfähig bleibt."
+                    )
                 if not dekodiert:
                     self.output.emit(
                         "Keine gültigen TETRA-Bursts in diesem Zeitfenster dekodiert."
@@ -3396,6 +3467,11 @@ class TetraDecoder(QtCore.QObject):
                         os.remove(bits_path)
                     except OSError:
                         pass
+        if self._running.is_set():
+            self.output.emit(
+                "Windows-Dekodierlauf beendet; weitere Blöcke können bei Bedarf "
+                "erneut gestartet werden."
+            )
 
     def _legacy_pipeline(self, frequency: float, audio_enabled: bool):
         receiver_cmd = ["receiver1", "-f", str(int(frequency)), "-p", str(self.ppm)]
@@ -3821,6 +3897,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.freq_history = deque(maxlen=10)
         self.scan_results = {}
         self.current_frequency = None
+        self.current_tune_frequency = None
+        self.current_xlate_hz = 0.0
+        self.current_iq_mode = "normal"
         self.cells = {}
         self.packet_counts = {}
         self.talkgroups = {}
@@ -4946,6 +5025,12 @@ class MainWindow(QtWidgets.QMainWindow):
             item = self._tabellen_item(wert, limit=90)
             if spalte == 0:
                 item.setData(QtCore.Qt.UserRole, freq)
+                item.setData(
+                    QtCore.Qt.UserRole + 1,
+                    float(info.get("probe_frequency_hz") or freq),
+                )
+                item.setData(QtCore.Qt.UserRole + 2, float(info.get("xlate_hz") or 0.0))
+                item.setData(QtCore.Qt.UserRole + 3, str(info.get("iq_mode") or "normal"))
             elif spalte == 2:
                 item.setData(QtCore.Qt.UserRole, float(info.get("power", 0.0)))
             if farbe is not None:
@@ -5251,6 +5336,9 @@ class MainWindow(QtWidgets.QMainWindow):
             self.log.appendPlainText(f"Gew\u00e4hlte Frequenz: {freq/1e6:.3f} MHz")
         self.freq_history.appendleft(freq / 1e6)
         self.current_frequency = freq
+        self.current_tune_frequency = freq
+        self.current_xlate_hz = 0.0
+        self.current_iq_mode = "normal"
         self.player.start(freq)
         self.tetra_start_btn.setEnabled(True)
         if self.tetra_auto_cb.isChecked():
@@ -5286,6 +5374,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self._update_ppm(self.ppm_spin.value())
         self.decoder.device_id = device_id
         self.decoder.gain = _normalize_gain_setting(self.config.get("gain", "max"))
+        self.decoder.tune_frequency_hz = self.current_tune_frequency or self.current_frequency
+        self.decoder.xlate_hz = float(self.current_xlate_hz or 0.0)
+        self.decoder.iq_mode = str(self.current_iq_mode or "normal")
         self.scanner.stop()
         self.player.stop()
         self.tetra_start_btn.setEnabled(False)
@@ -5322,7 +5413,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self._append_plain_text(
             self.log,
             f"Dekodierung gestartet mit Gerät {device_text} ({name}) "
-            f"bei {self.current_frequency/1e6:.3f} MHz"
+            f"bei {self.current_frequency/1e6:.3f} MHz "
+            f"(Tuning {self.decoder.tune_frequency_hz/1e6:.4f} MHz, "
+            f"Kanalversatz {self.decoder.xlate_hz:+.0f} Hz, IQ {self.decoder.iq_mode})"
         )
         self.decoder.start(self.current_frequency)
 
@@ -5443,6 +5536,12 @@ class MainWindow(QtWidgets.QMainWindow):
             item = self._tabellen_item(value, limit=limit)
             if column == 0:
                 item.setData(QtCore.Qt.UserRole, freq)
+                item.setData(
+                    QtCore.Qt.UserRole + 1,
+                    float(info.get("probe_frequency_hz") or freq),
+                )
+                item.setData(QtCore.Qt.UserRole + 2, float(info.get("xlate_hz") or 0.0))
+                item.setData(QtCore.Qt.UserRole + 3, str(info.get("iq_mode") or "normal"))
             elif column == 1:
                 item.setData(QtCore.Qt.UserRole, float(info.get("power", 0.0)))
             if status == "bestätigt":
@@ -5457,9 +5556,15 @@ class MainWindow(QtWidgets.QMainWindow):
 
         lines = info.get("lines") or []
         if lines and status in ("bestätigt", "unklar"):
-            for line in lines[:80]:
-                self._append_plain_text(self.tetra_output, f"[{freq/1e6:.4f} MHz] {line}")
-                self._append_decoder_data(line)
+            angezeigte_zeilen = 0
+            for line in lines[:300]:
+                if _decoder_line_for_ui(line) and angezeigte_zeilen < 80:
+                    self._append_plain_text(
+                        self.tetra_output,
+                        f"[{freq/1e6:.4f} MHz] {line}",
+                    )
+                    self._append_decoder_data(line)
+                    angezeigte_zeilen += 1
                 if status == "bestätigt":
                     self.current_frequency = freq
                     self.parse_cell_info(line)
@@ -5468,6 +5573,9 @@ class MainWindow(QtWidgets.QMainWindow):
                     self.parse_talkgroups(line)
             if status == "bestätigt":
                 self.freq_label.setText(f"Frequenz: {freq/1e6:.3f} MHz")
+                self.current_tune_frequency = float(info.get("probe_frequency_hz") or freq)
+                self.current_xlate_hz = float(info.get("xlate_hz") or 0.0)
+                self.current_iq_mode = str(info.get("iq_mode") or "normal")
                 self.tetra_start_btn.setEnabled(True)
                 self.signal_search_table.selectRow(row)
                 self._scroll_zeile_sichtbar(self.signal_search_table, row, immer=True)
@@ -5491,13 +5599,27 @@ class MainWindow(QtWidgets.QMainWindow):
         self._refresh_dashboard_status()
 
     def _selected_signal_candidate(self):
-        row = self.signal_search_table.currentRow()
-        tabelle = self.signal_search_table
+        kandidaten = [(self.signal_search_table, 2)]
+        if hasattr(self, "overview_channel_table"):
+            kandidaten.append((self.overview_channel_table, 1))
+
+        tabelle = None
         status_spalte = 2
-        if row < 0 and hasattr(self, "overview_channel_table"):
-            row = self.overview_channel_table.currentRow()
-            tabelle = self.overview_channel_table
-            status_spalte = 1
+        row = -1
+        for tab, spalte in kandidaten:
+            auswahl = tab.selectionModel().selectedRows() if tab.selectionModel() else []
+            if auswahl:
+                tabelle = tab
+                status_spalte = spalte
+                row = auswahl[0].row()
+                break
+        if row < 0:
+            for tab, spalte in kandidaten:
+                if tab.currentRow() >= 0:
+                    tabelle = tab
+                    status_spalte = spalte
+                    row = tab.currentRow()
+                    break
         if row < 0:
             return None
         freq_item = tabelle.item(row, 0)
@@ -5510,8 +5632,17 @@ class MainWindow(QtWidgets.QMainWindow):
                 freq = float(freq_item.text().split()[0].replace(",", ".")) * 1e6
             except (ValueError, IndexError):
                 return None
+        probe_frequency = freq_item.data(QtCore.Qt.UserRole + 1) or freq
+        xlate_hz = freq_item.data(QtCore.Qt.UserRole + 2) or 0.0
+        iq_mode = freq_item.data(QtCore.Qt.UserRole + 3) or "normal"
         status = status_item.text() if status_item else ""
-        return float(freq), status
+        return {
+            "frequency": float(freq),
+            "probe_frequency": float(probe_frequency),
+            "xlate_hz": float(xlate_hz),
+            "iq_mode": str(iq_mode),
+            "status": status,
+        }
 
     @QtCore.pyqtSlot(QtWidgets.QTableWidgetItem)
     def _decode_signal_candidate_from_item(self, item):
@@ -5529,13 +5660,17 @@ class MainWindow(QtWidgets.QMainWindow):
         if not selected:
             self.log.appendPlainText("Bitte zuerst eine Frequenz aus der Signalsuche markieren.")
             return
-        freq, status = selected
+        freq = selected["frequency"]
+        status = selected["status"]
         self.stop_monitoring()
         self.stop_tetra_signal_search(wait=True)
         self._set_manual_lock(True)
         self.freq_label.setText(f"Frequenz: {freq/1e6:.3f} MHz")
         self.freq_history.appendleft(freq / 1e6)
         self.current_frequency = freq
+        self.current_tune_frequency = selected["probe_frequency"]
+        self.current_xlate_hz = selected["xlate_hz"]
+        self.current_iq_mode = selected["iq_mode"]
         self.tetra_start_btn.setEnabled(True)
         if status != "bestätigt":
             self.log.appendPlainText(
@@ -5544,7 +5679,10 @@ class MainWindow(QtWidgets.QMainWindow):
             )
         else:
             self.log.appendPlainText(
-                f"Bestätigte TETRA-Frequenz übernommen: {freq/1e6:.4f} MHz."
+                f"Bestätigte TETRA-Frequenz übernommen: {freq/1e6:.4f} MHz "
+                f"(Tuning {self.current_tune_frequency/1e6:.4f} MHz, "
+                f"Kanalversatz {self.current_xlate_hz:+.0f} Hz, "
+                f"IQ {self.current_iq_mode})."
             )
         self._refresh_dashboard_status()
         self.start_decoding()
@@ -5594,6 +5732,9 @@ class MainWindow(QtWidgets.QMainWindow):
         if sichtbar:
             self._append_decoder_data(line)
         if line.startswith("Audioausgabe:"):
+            self.audio_status_label.setText(f"Audio-Status: {line.split(':', 1)[1].strip()}")
+            self._refresh_dashboard_status()
+        if line.startswith("Audiohinweis:"):
             self.audio_status_label.setText(f"Audio-Status: {line.split(':', 1)[1].strip()}")
             self._refresh_dashboard_status()
         self.parse_cell_info(line)

--- a/sdr_gui.py
+++ b/sdr_gui.py
@@ -18,7 +18,6 @@ import pkgutil
 import ctypes.util
 import shlex
 import glob
-import socket
 import faulthandler
 import traceback
 try:
@@ -3143,103 +3142,6 @@ class DecodedAudioPlayer(QtCore.QObject):
             return False
 
 
-class PcmAudioStreamClient(QtCore.QObject):
-    """Empfängt Live-PCM über TCP und reicht die Daten ohne Mitschnitt weiter."""
-
-    audio = QtCore.pyqtSignal(bytes)
-    status = QtCore.pyqtSignal(str)
-    level = QtCore.pyqtSignal(float)
-    stopped = QtCore.pyqtSignal()
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self._thread = None
-        self._running = threading.Event()
-        self._socket = None
-        self._socket_lock = threading.RLock()
-
-    def is_running(self):
-        return self._thread is not None and self._thread.is_alive()
-
-    def start(self, host: str, port: int):
-        if self.is_running():
-            return
-        host = (host or "127.0.0.1").strip()
-        port = int(port)
-        self._running.set()
-        self._thread = threading.Thread(
-            target=self._run,
-            args=(host, port),
-            daemon=True,
-        )
-        self._thread.start()
-
-    def stop(self):
-        self._running.clear()
-        with self._socket_lock:
-            sock = self._socket
-            self._socket = None
-        if sock:
-            try:
-                sock.shutdown(socket.SHUT_RDWR)
-            except OSError:
-                pass
-            try:
-                sock.close()
-            except OSError:
-                pass
-        if (
-            self._thread
-            and self._thread.is_alive()
-            and threading.current_thread() is not self._thread
-        ):
-            self._thread.join(timeout=2)
-        if not self.is_running():
-            self._thread = None
-
-    def _run(self, host: str, port: int):
-        rest = b""
-        try:
-            self.status.emit(f"Stream verbindet zu {host}:{port}")
-            with socket.create_connection((host, port), timeout=4) as sock:
-                sock.settimeout(0.5)
-                with self._socket_lock:
-                    self._socket = sock
-                self.status.emit(f"Stream verbunden: {host}:{port}")
-                while self._running.is_set():
-                    try:
-                        chunk = sock.recv(4096)
-                    except socket.timeout:
-                        continue
-                    if not chunk:
-                        self.status.emit("Stream beendet")
-                        break
-                    data = rest + chunk
-                    if len(data) % 2:
-                        rest = data[-1:]
-                        data = data[:-1]
-                    else:
-                        rest = b""
-                    if not data:
-                        continue
-                    self.audio.emit(data)
-                    try:
-                        werte = np.frombuffer(data, dtype=np.int16).astype(np.int32)
-                        if werte.size:
-                            pegel = min(1.0, float(np.max(np.abs(werte))) / 32768.0)
-                            self.level.emit(pegel)
-                    except Exception:
-                        pass
-        except Exception as exc:
-            if self._running.is_set():
-                self.status.emit(f"Stream nicht verbunden: {exc}")
-        finally:
-            self._running.clear()
-            with self._socket_lock:
-                self._socket = None
-            self.stopped.emit()
-
-
 class TetraAudioBackend:
     """Startet die WSL-Codec-Kette und liefert PCM ohne dauerhafte Dateien."""
 
@@ -4065,8 +3967,6 @@ class MainWindow(QtWidgets.QMainWindow):
             "tetra_max_candidates": 0,
             "audio_mode": "safe",
             "record_audio": False,
-            "audio_stream_host": "127.0.0.1",
-            "audio_stream_port": 7355,
             "log_decoder_lines": False,
             "monitor_cycle_delay_sec": 5,
             "ui_profile_version": 3,
@@ -4132,9 +4032,6 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         self.decoder = TetraDecoder(ppm=self.config.get("ppm", 0), parent=self)
         self.dec_audio_player = DecodedAudioPlayer(parent=self)
-        self.stream_audio_player = DecodedAudioPlayer(parent=self)
-        self.audio_stream_client = PcmAudioStreamClient(parent=self)
-        self._stream_record_requested = False
         self._encrypted_notice_shown = False
 
         self.scheduler_timer = QtCore.QTimer(self)
@@ -4177,10 +4074,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.decoder.finished.connect(self._decoder_finished)
         self.decoder.audio.connect(self.dec_audio_player.process)
         self.decoder.encrypted.connect(self._encrypted_signal)
-        self.audio_stream_client.audio.connect(self.stream_audio_player.process)
-        self.audio_stream_client.status.connect(self._stream_status)
-        self.audio_stream_client.level.connect(self._stream_level)
-        self.audio_stream_client.stopped.connect(self._stream_stopped)
 
         self.tetra_start_btn.clicked.connect(self.start_decoding)
         self.tetra_stop_btn.clicked.connect(self.stop_decoding)
@@ -4204,14 +4097,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.play_audio_cb.toggled.connect(self._toggle_dec_audio)
         self.record_audio_cb.toggled.connect(
             lambda checked: self.config.__setitem__("record_audio", bool(checked))
-        )
-        self.audio_stream_start_btn.clicked.connect(self.start_audio_stream)
-        self.audio_stream_stop_btn.clicked.connect(self.stop_audio_stream)
-        self.audio_stream_host_edit.textChanged.connect(
-            lambda text: self.config.__setitem__("audio_stream_host", text.strip())
-        )
-        self.audio_stream_port_spin.valueChanged.connect(
-            lambda value: self.config.__setitem__("audio_stream_port", int(value))
         )
         self.log_decoder_lines_cb.toggled.connect(
             lambda checked: self.config.__setitem__("log_decoder_lines", bool(checked))
@@ -4539,8 +4424,7 @@ class MainWindow(QtWidgets.QMainWindow):
         audio_bar.addWidget(self.audio_mode_combo)
         self.play_audio_cb = QtWidgets.QCheckBox("Decoder-Audio")
         self.play_audio_cb.setToolTip(
-            "Aktiviert Audio aus einer audiofähigen Decoder-Kette. "
-            "Der Live-Stream wird separat gestartet."
+            "Aktiviert Audio aus der internen TETRA-Decoder-Kette."
         )
         self.play_audio_cb.setChecked(self.audio_mode_combo.currentData() != "off")
         audio_bar.addWidget(self.play_audio_cb)
@@ -4557,36 +4441,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.audio_status_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
         audio_bar.addWidget(self.audio_status_label)
         audio_data_layout.addLayout(audio_bar)
-
-        stream_bar = QtWidgets.QHBoxLayout()
-        stream_bar.addWidget(QtWidgets.QLabel("Live-Stream:"))
-        self.audio_stream_host_edit = QtWidgets.QLineEdit(
-            str(self.config.get("audio_stream_host", "127.0.0.1"))
-        )
-        self.audio_stream_host_edit.setFixedWidth(130)
-        stream_bar.addWidget(self.audio_stream_host_edit)
-        self.audio_stream_port_spin = QtWidgets.QSpinBox()
-        self.audio_stream_port_spin.setRange(1, 65535)
-        self.audio_stream_port_spin.setValue(int(self.config.get("audio_stream_port", 7355)))
-        stream_bar.addWidget(self.audio_stream_port_spin)
-        self.audio_stream_start_btn = aktionsknopf(
-            "Stream starten",
-            QtWidgets.QStyle.SP_MediaPlay,
-            primaer=True,
-        )
-        self.audio_stream_stop_btn = aktionsknopf("Stream stoppen", QtWidgets.QStyle.SP_MediaStop)
-        self.audio_stream_stop_btn.setEnabled(False)
-        stream_bar.addWidget(self.audio_stream_start_btn)
-        stream_bar.addWidget(self.audio_stream_stop_btn)
-        self.audio_stream_status_label = QtWidgets.QLabel(
-            "PCM 16 Bit, mono, 8000 Hz, ohne Mitschnitt"
-        )
-        self.audio_stream_status_label.setObjectName("statusDetail")
-        self.audio_stream_status_label.setWordWrap(True)
-        self.audio_stream_status_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
-        stream_bar.addWidget(self.audio_stream_status_label)
-        stream_bar.addStretch()
-        audio_data_layout.addLayout(stream_bar)
 
         self.decoder_data_table = QtWidgets.QTableWidget(0, 4)
         self.decoder_data_table.setHorizontalHeaderLabels(
@@ -5179,98 +5033,6 @@ class MainWindow(QtWidgets.QMainWindow):
         if immer or folgen:
             tabelle.scrollToItem(item, QtWidgets.QAbstractItemView.EnsureVisible)
 
-    def _audio_stream_endpoint(self):
-        host = "127.0.0.1"
-        port = 7355
-        if hasattr(self, "audio_stream_host_edit"):
-            host = self.audio_stream_host_edit.text().strip() or host
-        else:
-            host = str(self.config.get("audio_stream_host", host)).strip() or host
-        if hasattr(self, "audio_stream_port_spin"):
-            port = int(self.audio_stream_port_spin.value())
-        else:
-            port = int(self.config.get("audio_stream_port", port))
-        return host, port
-
-    def start_audio_stream(self):
-        """Startet den Live-PCM-Eingang ohne automatische Dateiausgabe."""
-        host, port = self._audio_stream_endpoint()
-        self.config["audio_stream_host"] = host
-        self.config["audio_stream_port"] = int(port)
-        self._stream_record_requested = bool(self.record_audio_cb.isChecked())
-        self.stream_audio_player.stop()
-        self.audio_stream_start_btn.setEnabled(False)
-        self.audio_stream_stop_btn.setEnabled(True)
-        self.audio_stream_status_label.setText(f"Verbinde {host}:{port}")
-        self.audio_stream_status_label.setToolTip(f"Verbinde {host}:{port}")
-        self.audio_status_label.setText("Audio-Status: Stream verbindet")
-        self.audio_status_label.setToolTip(f"Verbinde {host}:{port}")
-        self.audio_stream_client.start(host, port)
-        self._refresh_dashboard_status()
-
-    def stop_audio_stream(self):
-        """Stoppt den Live-PCM-Eingang."""
-        lief = bool(
-            hasattr(self, "audio_stream_client")
-            and self.audio_stream_client.is_running()
-        )
-        if hasattr(self, "audio_stream_client"):
-            self.audio_stream_client.stop()
-        if hasattr(self, "stream_audio_player"):
-            self.stream_audio_player.stop()
-        if hasattr(self, "audio_stream_start_btn"):
-            self.audio_stream_start_btn.setEnabled(True)
-            self.audio_stream_stop_btn.setEnabled(False)
-        if lief and hasattr(self, "audio_stream_status_label"):
-            self.audio_stream_status_label.setText("Stream gestoppt")
-        if lief and hasattr(self, "audio_status_label"):
-            self.audio_status_label.setText("Audio-Status: Stream gestoppt")
-        self._refresh_dashboard_status()
-
-    @QtCore.pyqtSlot(str)
-    def _stream_status(self, text: str):
-        kurz, detail = self._format_stream_status(text)
-        if text.startswith("Stream verbunden"):
-            if not self.stream_audio_player.start(record=self._stream_record_requested):
-                kurz = "Audiogerät nicht verfügbar"
-                detail = "Der Stream ist verbunden, aber der Audioausgang konnte nicht geöffnet werden."
-        if hasattr(self, "audio_stream_status_label"):
-            self.audio_stream_status_label.setText(kurz)
-            self.audio_stream_status_label.setToolTip(detail)
-        if hasattr(self, "audio_status_label"):
-            self.audio_status_label.setText(f"Audio-Status: {kurz}")
-            self.audio_status_label.setToolTip(detail)
-        self._refresh_dashboard_status()
-
-    def _format_stream_status(self, text: str):
-        host, port = self._audio_stream_endpoint()
-        detail = text
-        lower = text.lower()
-        if "nicht verbunden" in lower:
-            if "10061" in text or "connection refused" in lower or "verweigert" in lower:
-                return f"Kein Audio-Backend auf {host}:{port}", detail
-            return f"Stream nicht verbunden ({host}:{port})", detail
-        if text.startswith("Stream verbunden"):
-            return f"Stream verbunden ({host}:{port})", detail
-        if text.startswith("Stream verbindet"):
-            return f"Stream verbindet ({host}:{port})", detail
-        if text.startswith("Stream beendet"):
-            return "Stream beendet", detail
-        return text, detail
-
-    @QtCore.pyqtSlot(float)
-    def _stream_level(self, level: float):
-        if level > 0.05:
-            self.activity_led.set_color("yellow")
-            QtCore.QTimer.singleShot(300, lambda: self.activity_led.set_color("green"))
-
-    @QtCore.pyqtSlot()
-    def _stream_stopped(self):
-        self.stream_audio_player.stop()
-        self.audio_stream_start_btn.setEnabled(True)
-        self.audio_stream_stop_btn.setEnabled(False)
-        self._refresh_dashboard_status()
-
     def _refresh_dashboard_status(self):
         if not hasattr(self, "dashboard_device_value"):
             return
@@ -5320,11 +5082,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         status = self.audio_status_label.text().replace("Audio-Status:", "").strip()
         self.dashboard_audio_value.setText(status or "wartet")
-        if hasattr(self, "audio_stream_client") and self.audio_stream_client.is_running():
-            host, port = self._audio_stream_endpoint()
-            self.dashboard_audio_detail.setText(f"Stream {host}:{port}")
-        else:
-            self.dashboard_audio_detail.setText(f"Modus: {self._audio_mode_text()}")
+        self.dashboard_audio_detail.setText(f"Modus: {self._audio_mode_text()}")
 
         talkgroups = getattr(self, "talkgroups", {})
         selected_talkgroups = getattr(self, "selected_talkgroups", set())
@@ -6131,7 +5889,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.scanner.stop()
         self.player.stop()
         self.stop_decoding()
-        self.stop_audio_stream()
         self._refresh_dashboard_status()
 
     def closeEvent(self, event):
@@ -6153,9 +5910,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.config["calibrate_on_start"] = bool(self.calibrate_on_start_cb.isChecked())
         self.config["audio_mode"] = self._audio_mode()
         self.config["record_audio"] = bool(self.record_audio_cb.isChecked())
-        host, port = self._audio_stream_endpoint()
-        self.config["audio_stream_host"] = host
-        self.config["audio_stream_port"] = int(port)
         self.config["log_decoder_lines"] = bool(self.log_decoder_lines_cb.isChecked())
         self.config["ui_profile_version"] = 3
         self.config["tetra_probe_all_candidates"] = bool(

--- a/sdr_gui.py
+++ b/sdr_gui.py
@@ -19,6 +19,8 @@ import ctypes.util
 import shlex
 import glob
 import socket
+import faulthandler
+import traceback
 try:
     import qdarkstyle
 except Exception:
@@ -657,6 +659,7 @@ def _extract_sysinfo(line: str):
 
 LOG_DIR = os.path.expanduser("~")
 CONFIG_FILE = os.path.expanduser("~/.tetra_gui_config.json")
+CRASH_LOG_FILE = os.path.join(LOG_DIR, "tetra_crash.log")
 logger = logging.getLogger("tetra")
 handler = TimedRotatingFileHandler(
     os.path.join(LOG_DIR, "tetra.log"), when="midnight", backupCount=7, encoding="utf-8"
@@ -664,6 +667,56 @@ handler = TimedRotatingFileHandler(
 handler.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
 logger.setLevel(logging.INFO)
 logger.addHandler(handler)
+_CRASH_LOG_HANDLE = None
+
+
+def _install_crash_logging():
+    """Schreibt Python- und native Fehlerspuren in eine kompakte Crash-Datei."""
+    global _CRASH_LOG_HANDLE
+    if _CRASH_LOG_HANDLE is not None:
+        return
+
+    try:
+        _CRASH_LOG_HANDLE = open(CRASH_LOG_FILE, "a", encoding="utf-8", buffering=1)
+        _CRASH_LOG_HANDLE.write(
+            f"\n--- Start {datetime.now().isoformat(timespec='seconds')} ---\n"
+        )
+        faulthandler.enable(file=_CRASH_LOG_HANDLE, all_threads=True)
+    except Exception:
+        _CRASH_LOG_HANDLE = None
+        return
+
+    original_excepthook = sys.excepthook
+
+    def logge_ausnahme(exc_type, exc_value, exc_traceback):
+        logger.exception(
+            "Unbehandelte Ausnahme",
+            exc_info=(exc_type, exc_value, exc_traceback),
+        )
+        try:
+            _CRASH_LOG_HANDLE.write(
+                f"\nUnbehandelte Ausnahme {datetime.now().isoformat(timespec='seconds')}\n"
+            )
+            traceback.print_exception(
+                exc_type,
+                exc_value,
+                exc_traceback,
+                file=_CRASH_LOG_HANDLE,
+            )
+        except Exception:
+            pass
+        original_excepthook(exc_type, exc_value, exc_traceback)
+
+    sys.excepthook = logge_ausnahme
+
+    if hasattr(threading, "excepthook"):
+        original_threading_excepthook = threading.excepthook
+
+        def logge_thread_ausnahme(args):
+            logge_ausnahme(args.exc_type, args.exc_value, args.exc_traceback)
+            original_threading_excepthook(args)
+
+        threading.excepthook = logge_thread_ausnahme
 
 ERSTELLUNGSJAHR = 2026
 APP_NAME = "TETRA Decode"
@@ -918,6 +971,8 @@ def _capture_rtl_sdr_iq(
     ppm: int,
     gain,
     device_id=None,
+    stop_event: threading.Event | None = None,
+    proc_callback=None,
 ):
     samples = max(16_384, int(sample_rate * seconds))
     cmd = [
@@ -931,14 +986,39 @@ def _capture_rtl_sdr_iq(
     if device_id is not None:
         cmd.extend(["-d", str(device_id)])
     cmd.append("-")
+    proc = None
+    timeout_seconds = max(8.0, float(seconds) + 8.0)
+    deadline = time.time() + timeout_seconds
     try:
-        raw = subprocess.check_output(
+        proc = subprocess.Popen(
             cmd,
+            stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            timeout=max(8, int(seconds) + 8),
             **_hidden_subprocess_kwargs(),
         )
+        if proc_callback:
+            proc_callback(proc)
+
+        while True:
+            if stop_event is not None and not stop_event.is_set():
+                _terminate_process_list([proc])
+                raise RuntimeError("rtl_sdr-Aufnahme abgebrochen.")
+            remaining = max(0.05, min(0.25, deadline - time.time()))
+            try:
+                raw, _ = proc.communicate(timeout=remaining)
+                break
+            except subprocess.TimeoutExpired:
+                if time.time() >= deadline:
+                    _terminate_process_list([proc])
+                    raise RuntimeError(
+                        f"rtl_sdr-Aufnahme fehlgeschlagen: Timeout nach "
+                        f"{timeout_seconds:.1f} Sekunden."
+                    )
+    except RuntimeError:
+        raise
     except Exception as exc:
+        if proc and proc.poll() is None:
+            _terminate_process_list([proc])
         raise RuntimeError(f"rtl_sdr-Aufnahme fehlgeschlagen: {exc}") from exc
     if len(raw) < 4096:
         raise RuntimeError(f"rtl_sdr lieferte zu wenige IQ-Daten ({len(raw)} Byte).")
@@ -954,6 +1034,8 @@ def _estimate_reference_peak(
     seconds: float = 1.0,
     tune_offset_hz: float = 50_000.0,
     search_span_hz: float = 100_000.0,
+    stop_event: threading.Event | None = None,
+    proc_callback=None,
 ):
     tune_hz = reference_hz - tune_offset_hz
     raw = _capture_rtl_sdr_iq(
@@ -963,6 +1045,8 @@ def _estimate_reference_peak(
         ppm,
         gain,
         device_id=device_id,
+        stop_event=stop_event,
+        proc_callback=proc_callback,
     )
     iq_u8 = np.frombuffer(raw, dtype=np.uint8)
     if iq_u8.size % 2:
@@ -1894,9 +1978,22 @@ class CalibrationWorker(QtCore.QThread):
         self.ppm = ppm
         self.gain = gain
         self._running = threading.Event()
+        self._procs = []
+        self._proc_lock = threading.RLock()
 
     def stop(self):
         self._running.clear()
+        self._terminate_processes()
+
+    def _add_proc(self, proc):
+        with self._proc_lock:
+            self._procs.append(proc)
+
+    def _terminate_processes(self):
+        with self._proc_lock:
+            procs = list(self._procs)
+            self._procs = []
+        _terminate_process_list(procs)
 
     def run(self):
         self._running.set()
@@ -1907,15 +2004,24 @@ class CalibrationWorker(QtCore.QThread):
 
             gain_for_ppm = self.gain
             if self.mode in ("gain", "both"):
-                gain_result = self._auto_gain()
+                try:
+                    gain_result = self._auto_gain()
+                except Exception as exc:
+                    self.log.emit(f"RF-Gain-Automatik fehlgeschlagen: {exc}")
+                    gain_result = None
                 if gain_result and self._running.is_set():
                     gain_for_ppm = gain_result["gain"]
                     self.gain_ready.emit(gain_result)
 
             if self.mode in ("ppm", "both") and self._running.is_set():
-                self._auto_ppm(gain_for_ppm)
+                try:
+                    self._auto_ppm(gain_for_ppm)
+                except Exception as exc:
+                    if self._running.is_set():
+                        self.log.emit(f"PPM-Kalibrierung fehlgeschlagen: {exc}")
         finally:
             self._running.clear()
+            self._terminate_processes()
 
     def _auto_ppm(self, gain):
         self.log.emit(
@@ -1929,7 +2035,11 @@ class CalibrationWorker(QtCore.QThread):
             seconds=3.0,
             tune_offset_hz=self._tune_offset_hz(),
             search_span_hz=self.search_span_hz,
+            stop_event=self._running,
+            proc_callback=self._add_proc,
         )
+        if not self._running.is_set():
+            return
         exact_ppm = self.ppm + result["ppm_delta"]
         result["old_ppm"] = int(self.ppm)
         result["new_ppm_exact"] = float(exact_ppm)
@@ -1966,6 +2076,8 @@ class CalibrationWorker(QtCore.QThread):
                     seconds=0.55,
                     tune_offset_hz=self._tune_offset_hz(),
                     search_span_hz=self.search_span_hz,
+                    stop_event=self._running,
+                    proc_callback=self._add_proc,
                 )
             except Exception as exc:
                 self.log.emit(f"Gain {gain:.1f} dB konnte nicht gemessen werden: {exc}")
@@ -3482,6 +3594,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._signal_search_rows = {}
         self._overview_signal_rows = {}
         self.calibration_worker = None
+        self._closing = False
         self.monitoring_active = False
         self.monitor_timer = QtCore.QTimer(self)
         self.monitor_timer.setSingleShot(True)
@@ -3670,7 +3783,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 )
 
         if self.config.get("calibrate_on_start", False):
-            QtCore.QTimer.singleShot(1500, lambda: self.start_calibration("both"))
+            QtCore.QTimer.singleShot(1500, self._start_calibration_on_start)
 
     def _build_modern_tabs(self):
         """Erstellt die moderne Hauptoberfläche."""
@@ -4754,6 +4867,8 @@ class MainWindow(QtWidgets.QMainWindow):
     def _run_monitoring_cycle(self):
         if not self.monitoring_active:
             return
+        if self._closing:
+            return
         if self.calibration_worker and self.calibration_worker.isRunning():
             self.monitor_timer.start(2000)
             return
@@ -4816,8 +4931,15 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             self._apply_gain_setting(float(self.rf_gain_spin.value()))
 
+    def _start_calibration_on_start(self):
+        if self._closing:
+            return
+        self.start_calibration("both")
+
     def start_calibration(self, mode: str = "both"):
         """Startet PPM- und/oder RF-Gain-Kalibrierung auf der Referenzfrequenz."""
+        if self._closing:
+            return
         if self.calibration_worker and self.calibration_worker.isRunning():
             self.log.appendPlainText("Kalibrierung läuft bereits.")
             return
@@ -4855,10 +4977,20 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         worker.stop()
         if wait:
-            worker.wait(2000)
+            if not worker.wait(12000):
+                text = "Kalibrierung reagierte nicht rechtzeitig und wird hart beendet."
+                logger.warning(text)
+                try:
+                    self.log.appendPlainText(text)
+                except RuntimeError:
+                    pass
+                worker.terminate()
+                worker.wait(3000)
 
     @QtCore.pyqtSlot(dict)
     def _apply_ppm_calibration(self, result: dict):
+        if self._closing:
+            return
         new_ppm = int(result.get("new_ppm", self.ppm_spin.value()))
         ppm_delta = float(result.get("ppm_delta", new_ppm - self.ppm_spin.value()))
         if abs(ppm_delta) > 25.0 or abs(new_ppm) > 50:
@@ -4884,6 +5016,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
     @QtCore.pyqtSlot(dict)
     def _apply_gain_calibration(self, result: dict):
+        if self._closing:
+            return
         gain = float(result.get("gain", _resolve_gain_value(self.config.get("gain", "max"))))
         self.rf_gain_max_cb.blockSignals(True)
         self.rf_gain_max_cb.setChecked(False)
@@ -4904,6 +5038,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
     @QtCore.pyqtSlot()
     def _calibration_finished(self):
+        if self._closing:
+            self.calibration_worker = None
+            return
         if self.calibration_status_label.text() == "Kalibrierung läuft...":
             self.calibration_status_label.setText("Kalibrierung beendet.")
         self.calibration_worker = None
@@ -5356,8 +5493,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._refresh_dashboard_status()
 
     def closeEvent(self, event):
-        self.stop_calibration(wait=True)
-        self.stop_tetra_signal_search(wait=True)
+        self._closing = True
         self.stop()
         self._store_current_settings()
         self._persist_talkgroups_to_config()
@@ -5804,6 +5940,8 @@ if __name__ == "__main__":
         sys.argv = [sys.argv[0]] + rest_args
         _starte_cli_modus("CLI-Modus wurde per --cli angefordert.")
         raise SystemExit(0)
+
+    _install_crash_logging()
 
     if not _qt_xcb_verfuegbar():
         _starte_cli_modus(

--- a/sdr_gui.py
+++ b/sdr_gui.py
@@ -179,6 +179,7 @@ def _official_demod_script():
 
 _GNURADIO_PYTHON_CACHE = None
 _WSL_OSMO_CACHE = None
+_WSL_AUDIO_BACKEND_CACHE = None
 
 _RTL_U8_TO_COMPLEX64_SCRIPT = r"""
 import sys
@@ -369,6 +370,11 @@ def _find_gnuradio_python():
 def _wsl_path(path: str):
     if not sys.platform.startswith("win") or not shutil.which("wsl.exe"):
         return None
+    drive_match = re.match(r"^([A-Za-z]):\\(.*)$", os.path.abspath(path))
+    if drive_match:
+        drive = drive_match.group(1).lower()
+        rest = drive_match.group(2).replace("\\", "/")
+        return f"/mnt/{drive}/{rest}"
     try:
         result = subprocess.run(
             ["wsl.exe", "wslpath", "-a", path],
@@ -385,6 +391,59 @@ def _wsl_path(path: str):
         return None
     converted = result.stdout.strip()
     return converted or None
+
+
+def _wsl_resource_path(*parts):
+    for root in _resource_roots():
+        candidate = os.path.join(root, *parts)
+        if os.path.exists(candidate):
+            return _wsl_path(candidate)
+    return None
+
+
+def _wsl_tetra_audio_backend_paths():
+    if not (sys.platform.startswith("win") and shutil.which("wsl.exe")):
+        return None
+    paths = {
+        "backend": _wsl_resource_path("scripts", "tetra_audio_backend_wsl.py"),
+        "tetra_rx": _wsl_resource_path("tools", "osmocom-tetra", "bin", "tetra-rx"),
+        "cdecoder": _wsl_resource_path("tools", "tetra-codec", "bin", "cdecoder"),
+        "sdecoder": _wsl_resource_path("tools", "tetra-codec", "bin", "sdecoder"),
+    }
+    if all(paths.values()):
+        return paths
+    return None
+
+
+def _wsl_tetra_audio_backend_available():
+    global _WSL_AUDIO_BACKEND_CACHE
+    if _WSL_AUDIO_BACKEND_CACHE is not None:
+        return _WSL_AUDIO_BACKEND_CACHE
+    paths = _wsl_tetra_audio_backend_paths()
+    if not paths:
+        _WSL_AUDIO_BACKEND_CACHE = False
+        return False
+    check_cmd = (
+        "command -v python3 >/dev/null && "
+        f"test -x {shlex.quote(paths['tetra_rx'])} && "
+        f"test -x {shlex.quote(paths['cdecoder'])} && "
+        f"test -x {shlex.quote(paths['sdecoder'])} && "
+        f"test -f {shlex.quote(paths['backend'])}"
+    )
+    try:
+        result = subprocess.run(
+            ["wsl.exe", "--", "bash", "-lc", check_cmd],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=8,
+            check=False,
+            **_hidden_subprocess_kwargs(),
+        )
+    except Exception:
+        _WSL_AUDIO_BACKEND_CACHE = False
+        return False
+    _WSL_AUDIO_BACKEND_CACHE = result.returncode == 0
+    return _WSL_AUDIO_BACKEND_CACHE
 
 
 def _wsl_osmo_decoder_available():
@@ -589,7 +648,10 @@ def _classify_tetra_lines(lines, bits_size=0):
         if encrypted:
             audio_status = "verschlüsselt"
         elif clear_audio and (voice_service or resource):
-            audio_status = "unverschlüsselt, Backend fehlt"
+            if _wsl_tetra_audio_backend_available() or _legacy_audio_decoder_available():
+                audio_status = "unverschlüsselt"
+            else:
+                audio_status = "unverschlüsselt, Backend fehlt"
         elif clear_audio:
             audio_status = "unverschlüsselt"
         elif voice_service:
@@ -700,6 +762,11 @@ def _audio_hinweis_aus_tetra_zeilen(lines, bits_size=0):
     info = _classify_tetra_lines(lines, bits_size)
     audio = str(info.get("audio", ""))
     if audio in ("unverschlüsselt, Backend fehlt", "unverschlüsselt", "Audio möglich"):
+        if _wsl_tetra_audio_backend_available() or _legacy_audio_decoder_available():
+            return (
+                "Audiohinweis: unverschlüsselte TETRA-Sprache ist signalisiert; "
+                "das Audio-Backend kann PCM ausgeben."
+            )
         return (
             "Audiohinweis: unverschlüsselte TETRA-Sprache ist signalisiert, "
             "aber die aktuelle Windows-Pipeline liefert kein PCM-Audio."
@@ -3173,6 +3240,149 @@ class PcmAudioStreamClient(QtCore.QObject):
             self.stopped.emit()
 
 
+class TetraAudioBackend:
+    """Startet die WSL-Codec-Kette und liefert PCM ohne dauerhafte Dateien."""
+
+    def __init__(self, output_callback, audio_callback, audio_mode: str = "safe"):
+        self.output_callback = output_callback
+        self.audio_callback = audio_callback
+        self.audio_mode = audio_mode or "safe"
+        self.port = 42100 + (os.getpid() % 1000)
+        self._proc = None
+        self._running = threading.Event()
+        self._muted = self.audio_mode != "always"
+        self._status = ""
+        self._threads = []
+        self._lock = threading.RLock()
+
+    @staticmethod
+    def available():
+        return bool(_wsl_tetra_audio_backend_available())
+
+    def tetra_rx_command(self):
+        paths = _wsl_tetra_audio_backend_paths()
+        if not paths:
+            return None
+        exports = " ".join([
+            f"TETRA_AUDIO_UDP_PORT={int(self.port)}",
+            "TETRA_AUDIO_UDP_HOST=127.0.0.1",
+            "TETRA_AUDIO_RXID=1",
+        ])
+        return [
+            "wsl.exe",
+            "--",
+            "bash",
+            "-lc",
+            f"export {exports}; exec {shlex.quote(paths['tetra_rx'])} /dev/stdin",
+        ]
+
+    def start(self):
+        paths = _wsl_tetra_audio_backend_paths()
+        if not paths:
+            self.output_callback("Audioausgabe: TETRA-Audio-Backend fehlt.")
+            return False
+        cmd = (
+            f"exec python3 {shlex.quote(paths['backend'])} "
+            f"--udp-host 127.0.0.1 --udp-port {int(self.port)} "
+            f"--cdecoder {shlex.quote(paths['cdecoder'])} "
+            f"--sdecoder {shlex.quote(paths['sdecoder'])}"
+        )
+        try:
+            self._running.set()
+            self._proc = subprocess.Popen(
+                ["wsl.exe", "--", "bash", "-lc", cmd],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                **_hidden_subprocess_kwargs(),
+            )
+        except Exception as exc:
+            self._running.clear()
+            self.output_callback(f"Audioausgabe: Backend konnte nicht starten: {exc}")
+            return False
+
+        self._threads = [
+            threading.Thread(target=self._read_pcm, daemon=True),
+            threading.Thread(target=self._read_status, daemon=True),
+        ]
+        for thread in self._threads:
+            thread.start()
+        if self._muted:
+            self.output_callback(
+                "Audioausgabe: Backend gestartet, wartet auf unverschlüsselte Sprache."
+            )
+        else:
+            self.output_callback("Audioausgabe: Backend gestartet, PCM wird wiedergegeben.")
+        return True
+
+    def stop(self):
+        self._running.clear()
+        proc = self._proc
+        self._proc = None
+        if proc and proc.poll() is None:
+            try:
+                proc.terminate()
+                proc.wait(timeout=2)
+            except Exception:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+        for thread in self._threads:
+            if thread.is_alive() and threading.current_thread() is not thread:
+                thread.join(timeout=0.5)
+        self._threads = []
+
+    def set_clear_audio(self):
+        if self.audio_mode == "off":
+            return
+        with self._lock:
+            war_stumm = self._muted
+            self._muted = False
+        if war_stumm:
+            self.output_callback("Audioausgabe: unverschlüsselte Sprache erkannt, PCM aktiv.")
+
+    def set_encrypted(self):
+        if self.audio_mode == "always":
+            return
+        with self._lock:
+            war_aktiv = not self._muted
+            self._muted = True
+        if war_aktiv:
+            self.output_callback("Audioausgabe: verschlüsseltes Signal erkannt, PCM stumm.")
+
+    def _read_pcm(self):
+        proc = self._proc
+        if not proc or not proc.stdout:
+            return
+        while self._running.is_set():
+            try:
+                data = proc.stdout.read(320)
+            except Exception:
+                break
+            if not data:
+                if proc.poll() is not None:
+                    break
+                time.sleep(0.02)
+                continue
+            with self._lock:
+                stumm = self._muted
+            if not stumm:
+                self.audio_callback(data)
+
+    def _read_status(self):
+        proc = self._proc
+        if not proc or not proc.stderr:
+            return
+        for raw in iter(proc.stderr.readline, b""):
+            if not self._running.is_set():
+                break
+            text = raw.decode("utf-8", errors="replace").strip()
+            if not text or text == self._status:
+                continue
+            self._status = text
+            self.output_callback(f"Audioausgabe: {text}")
+
+
 class TetraDecoder(QtCore.QObject):
     """Startet osmocom-tetra-Werkzeuge und liefert dekodierte Ausgabe."""
 
@@ -3192,12 +3402,15 @@ class TetraDecoder(QtCore.QObject):
         self._audio_thread = None
         self._audio_path = None
         self._audio_mode = None
+        self._live_audio_backend = None
+        self.audio_requested = False
+        self.requested_audio_mode = "safe"
         self.tune_frequency_hz = None
         self.iq_mode = "normal"
         self.xlate_hz = 0.0
 
     def audio_output_supported(self):
-        return _legacy_audio_decoder_available()
+        return TetraAudioBackend.available() or _legacy_audio_decoder_available()
 
     def start(self, frequency: float):
         """Startet die Dekodierkette für die angegebene Frequenz."""
@@ -3210,6 +3423,9 @@ class TetraDecoder(QtCore.QObject):
     def stop(self):
         """Stoppt die Dekodierung und beendet Kindprozesse."""
         self._running.clear()
+        if self._live_audio_backend:
+            self._live_audio_backend.stop()
+            self._live_audio_backend = None
         self._terminate_processes()
         if (
             self._audio_thread
@@ -3271,6 +3487,126 @@ class TetraDecoder(QtCore.QObject):
             and shutil.which("rtl_sdr")
             and shutil.which("tetra-rx")
         )
+
+    def _windows_audio_pipeline_available(self):
+        return bool(
+            sys.platform.startswith("win")
+            and _official_demod_script()
+            and _find_gnuradio_python()
+            and shutil.which("rtl_sdr")
+            and TetraAudioBackend.available()
+        )
+
+    def _run_windows_audio_pipeline(self, frequency: float):
+        demod_script = _official_demod_script()
+        gnuradio_python = _find_gnuradio_python()
+        backend = TetraAudioBackend(
+            output_callback=self.output.emit,
+            audio_callback=self.audio.emit,
+            audio_mode=self.requested_audio_mode,
+        )
+        if not demod_script or not gnuradio_python or not backend.start():
+            self.output.emit("Audioausgabe: Live-Backend konnte nicht gestartet werden.")
+            return
+
+        self._live_audio_backend = backend
+        tetra_rx_cmd = backend.tetra_rx_command()
+        if not tetra_rx_cmd:
+            self.output.emit("Audioausgabe: WSL-tetra-rx für Audio fehlt.")
+            backend.stop()
+            self._live_audio_backend = None
+            return
+
+        self.output.emit(
+            "Nutze audiofähige TETRA-Pipeline "
+            "(rtl_sdr -> Kanalfilter -> simdemod3.py -> WSL-tetra-rx -> ETSI-Codec)."
+        )
+        try:
+            conv_env = _gnuradio_env_for(gnuradio_python)
+            conv_env["TETRA_IQ_MODE"] = str(self.iq_mode or "normal")
+            channelizer_env = _gnuradio_env_for(gnuradio_python)
+            channelizer_env.update({
+                "TETRA_XLATE_HZ": str(float(self.xlate_hz or 0.0)),
+                "TETRA_LOW_PASS": "12500",
+                "TETRA_TRANSITION": "2500",
+                "TETRA_OUT_RATE": "36000",
+            })
+            p1 = subprocess.Popen(
+                self._rtl_sdr_cmd(frequency),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                **_hidden_subprocess_kwargs(),
+            )
+            self._procs.append(p1)
+            pconv = subprocess.Popen(
+                [gnuradio_python, "-u", "-c", _RTL_U8_TO_COMPLEX64_SCRIPT],
+                stdin=p1.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                env=conv_env,
+                **_hidden_subprocess_kwargs(),
+            )
+            self._procs.append(pconv)
+            if p1.stdout:
+                p1.stdout.close()
+            pchan = subprocess.Popen(
+                [gnuradio_python, "-u", "-c", _TETRA_CHANNELIZER_SCRIPT],
+                stdin=pconv.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                env=channelizer_env,
+                **_hidden_subprocess_kwargs(),
+            )
+            self._procs.append(pchan)
+            if pconv.stdout:
+                pconv.stdout.close()
+            p2 = subprocess.Popen(
+                [gnuradio_python, demod_script],
+                stdin=pchan.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                **_hidden_subprocess_kwargs(),
+            )
+            self._procs.append(p2)
+            if pchan.stdout:
+                pchan.stdout.close()
+            p3 = subprocess.Popen(
+                tetra_rx_cmd,
+                stdin=p2.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                bufsize=1,
+                **_hidden_subprocess_kwargs(),
+            )
+            self._procs.append(p3)
+            if p2.stdout:
+                p2.stdout.close()
+
+            if p3.stdout:
+                for line in p3.stdout:
+                    if not self._running.is_set():
+                        break
+                    txt = line.strip()
+                    if not txt or txt == "EOF":
+                        continue
+                    if _tetra_line_indicates_encryption(txt):
+                        backend.set_encrypted()
+                        self.encrypted.emit()
+                    elif _tetra_line_indicates_clear_audio(txt):
+                        backend.set_clear_audio()
+                    if _decoder_line_for_ui(txt):
+                        self.output.emit(txt)
+
+                    if any(proc.poll() is not None for proc in (p1, pconv, pchan, p2)):
+                        break
+        except Exception as exc:
+            self.output.emit(f"Audiofähige TETRA-Dekodierung fehlgeschlagen: {exc}")
+        finally:
+            backend.stop()
+            self._live_audio_backend = None
 
     def _official_pipeline(self, frequency: float):
         demod_script = _official_demod_script()
@@ -3514,6 +3850,10 @@ class TetraDecoder(QtCore.QObject):
         self._audio_thread = None
         p3 = None
         try:
+            if self.audio_requested and self._windows_audio_pipeline_available():
+                self._run_windows_audio_pipeline(frequency)
+                return
+
             if self._windows_native_batch_available():
                 self._run_windows_native_batches(frequency)
                 return
@@ -3586,6 +3926,9 @@ class TetraDecoder(QtCore.QObject):
             self.output.emit(f"Decoder konnte nicht gestartet werden: {exc}")
         finally:
             self._running.clear()
+            if self._live_audio_backend:
+                self._live_audio_backend.stop()
+                self._live_audio_backend = None
             self._terminate_processes()
             if (
                 self._audio_thread
@@ -5386,6 +5729,8 @@ class MainWindow(QtWidgets.QMainWindow):
         rec = self.record_audio_cb.isChecked()
         audio_mode = self._audio_mode()
         audio_requested = audio_mode != "off" and self.play_audio_cb.isChecked()
+        self.decoder.audio_requested = bool(audio_requested)
+        self.decoder.requested_audio_mode = audio_mode
         if audio_requested and self.decoder.audio_output_supported():
             if self.dec_audio_player.start(record=rec):
                 if audio_mode == "always":

--- a/sdr_gui.py
+++ b/sdr_gui.py
@@ -506,12 +506,34 @@ def _terminate_process_list(procs):
                 pass
 
 
+def _tetra_line_indicates_encryption(line: str) -> bool:
+    encr = re.search(r"\bEncr=(\d+)\b", line, re.IGNORECASE)
+    if encr:
+        return int(encr.group(1)) > 0
+    air = re.search(r"\bAir encryption:\s*(\d+)\b", line, re.IGNORECASE)
+    if air:
+        return int(air.group(1)) > 0
+    return bool(re.search(r"\b(?:ENCRYPTED|CIPHER)\b", line, re.IGNORECASE))
+
+
+def _tetra_line_indicates_clear_audio(line: str) -> bool:
+    encr = re.search(r"\bEncr=(\d+)\b", line, re.IGNORECASE)
+    if encr:
+        return int(encr.group(1)) == 0
+    air = re.search(r"\bAir encryption:\s*(\d+)\b", line, re.IGNORECASE)
+    if air:
+        return int(air.group(1)) == 0
+    return False
+
+
 def _classify_tetra_lines(lines, bits_size=0):
     crc_ok = 0
     unit_ok = 0
     sysinfo = 0
     resource = 0
     encrypted = False
+    clear_audio = False
+    voice_service = False
     talkgroups = set()
 
     for line in lines:
@@ -523,8 +545,12 @@ def _classify_tetra_lines(lines, bits_size=0):
             sysinfo += 1
         if "RESOURCE" in line:
             resource += 1
-        if re.search(r"\b(?:Encr=|ENCRYPTED|CACH|LIP)\b", line, re.IGNORECASE):
+        if _tetra_line_indicates_encryption(line):
             encrypted = True
+        if _tetra_line_indicates_clear_audio(line):
+            clear_audio = True
+        if re.search(r"\bVoice service:\s*1\b", line, re.IGNORECASE):
+            voice_service = True
         talkgroups.update(extract_talkgroup_ids(line))
 
     confirmed = bool(crc_ok or unit_ok or sysinfo)
@@ -540,7 +566,16 @@ def _classify_tetra_lines(lines, bits_size=0):
             details.append(f"RESOURCE: {resource}")
         if talkgroups:
             details.append("Sprechgruppen/Adressen: " + ", ".join(sorted(talkgroups)[:8]))
-        audio_status = "verschlüsselt/unklar" if encrypted else "keine Audioframes"
+        if encrypted:
+            audio_status = "verschlüsselt"
+        elif clear_audio and (voice_service or resource):
+            audio_status = "unverschlüsselt, Backend fehlt"
+        elif clear_audio:
+            audio_status = "unverschlüsselt"
+        elif voice_service:
+            audio_status = "Audio möglich"
+        else:
+            audio_status = "keine Audioframes"
         return {
             "confirmed": True,
             "status": "bestätigt",
@@ -631,6 +666,9 @@ logger.setLevel(logging.INFO)
 logger.addHandler(handler)
 
 ERSTELLUNGSJAHR = 2026
+APP_NAME = "TETRA Decode"
+APP_WINDOW_TITLE = "TETRA Decode - SDR-Scanner"
+APP_SUBTITLE = "RTL-SDR TETRA-Suche, Sprechgruppen und Live-Audio"
 
 
 def _copyright_text():
@@ -641,6 +679,57 @@ def _copyright_text():
         else f"{ERSTELLUNGSJAHR} - {aktuelles_jahr}"
     )
     return f"© {jahre} Erik Schauer, do1ffe@darc.de"
+
+
+def _create_app_logo_pixmap(size: int = 48):
+    """Erzeugt ein kleines TETRA-Logo für Fenster und Kopfbereich."""
+    pixmap = QtGui.QPixmap(size, size)
+    pixmap.fill(QtCore.Qt.transparent)
+    painter = QtGui.QPainter(pixmap)
+    painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
+
+    rect = QtCore.QRectF(1, 1, size - 2, size - 2)
+    gradient = QtGui.QLinearGradient(0, 0, size, size)
+    gradient.setColorAt(0.0, QtGui.QColor("#0f766e"))
+    gradient.setColorAt(1.0, QtGui.QColor("#2563eb"))
+    painter.setBrush(QtGui.QBrush(gradient))
+    painter.setPen(QtGui.QPen(QtGui.QColor("#0b3b48"), max(1, size // 18)))
+    painter.drawRoundedRect(rect, size * 0.18, size * 0.18)
+
+    painter.setPen(QtGui.QPen(QtGui.QColor("#ffffff"), max(1, size // 16)))
+    mitte = QtCore.QPointF(size * 0.32, size * 0.68)
+    painter.drawLine(mitte, QtCore.QPointF(size * 0.32, size * 0.34))
+    painter.drawLine(
+        QtCore.QPointF(size * 0.24, size * 0.44),
+        QtCore.QPointF(size * 0.40, size * 0.44),
+    )
+    painter.drawArc(
+        QtCore.QRectF(size * 0.38, size * 0.27, size * 0.34, size * 0.34),
+        -45 * 16,
+        90 * 16,
+    )
+    painter.drawArc(
+        QtCore.QRectF(size * 0.30, size * 0.15, size * 0.58, size * 0.58),
+        -42 * 16,
+        84 * 16,
+    )
+
+    font = QtGui.QFont("Segoe UI", max(8, int(size * 0.22)), QtGui.QFont.Bold)
+    painter.setFont(font)
+    painter.drawText(
+        QtCore.QRectF(size * 0.18, size * 0.64, size * 0.64, size * 0.28),
+        QtCore.Qt.AlignCenter,
+        "TD",
+    )
+    painter.end()
+    return pixmap
+
+
+def _create_app_icon():
+    icon = QtGui.QIcon()
+    for size in (16, 24, 32, 48, 64, 128):
+        icon.addPixmap(_create_app_logo_pixmap(size))
+    return icon
 
 
 def list_sdr_devices():
@@ -2680,6 +2769,20 @@ class LEDIndicator(QtWidgets.QFrame):
         )
 
 
+class SortierbarerTabellenEintrag(QtWidgets.QTableWidgetItem):
+    """Tabelleneintrag, der numerische UserRole-Werte korrekt sortiert."""
+
+    def __lt__(self, other):
+        links = self.data(QtCore.Qt.UserRole)
+        rechts = other.data(QtCore.Qt.UserRole) if other is not None else None
+        if links is not None and rechts is not None:
+            try:
+                return float(links) < float(rechts)
+            except (TypeError, ValueError):
+                pass
+        return super().__lt__(other)
+
+
 class DecodedAudioPlayer(QtCore.QObject):
     """Spielt dekodierte TETRA-Audioframes über PyAudio ab."""
 
@@ -3059,7 +3162,7 @@ class TetraDecoder(QtCore.QObject):
                             continue
                         dekodiert = True
                         self.output.emit(txt)
-                        if re.search(r"\b(?:ENCRYPTED|Encr=[1-9]|CIPHER)\b", txt, re.I):
+                        if _tetra_line_indicates_encryption(txt):
                             self.encrypted.emit()
                 try:
                     p3.wait(timeout=5)
@@ -3188,7 +3291,7 @@ class TetraDecoder(QtCore.QObject):
                         break
                     txt = line.rstrip()
                     self.output.emit(txt)
-                    if re.search(r"\b(?:ENCRYPTED|Encr=[1-9]|CIPHER)\b", txt, re.I):
+                    if _tetra_line_indicates_encryption(txt):
                         self.encrypted.emit()
         except Exception as exc:
             self.output.emit(f"Decoder konnte nicht gestartet werden: {exc}")
@@ -3267,8 +3370,13 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("SDR-Scanner")
+        self.setWindowTitle(APP_WINDOW_TITLE)
         self.resize(900, 700)
+        self.app_icon = _create_app_icon()
+        self.setWindowIcon(self.app_icon)
+        app = QtWidgets.QApplication.instance()
+        if app is not None:
+            app.setWindowIcon(self.app_icon)
 
         # Widgets, die in mehreren Tabs verwendet werden
         self.start_btn = QtWidgets.QPushButton(
@@ -3598,10 +3706,15 @@ class MainWindow(QtWidgets.QMainWindow):
         tab_overview = QtWidgets.QWidget()
         overview_layout = standard_layout(tab_overview)
         kopf = QtWidgets.QHBoxLayout()
+        logo = QtWidgets.QLabel()
+        logo.setPixmap(_create_app_logo_pixmap(44))
+        logo.setFixedSize(48, 48)
+        logo.setAlignment(QtCore.Qt.AlignCenter)
+        kopf.addWidget(logo)
         titel_block = QtWidgets.QVBoxLayout()
-        titel = QtWidgets.QLabel("TETRA Decode")
+        titel = QtWidgets.QLabel(APP_NAME)
         titel.setObjectName("appTitle")
-        untertitel = QtWidgets.QLabel("SDR-Überwachung, Kanäle, Sprechgruppen und Audio")
+        untertitel = QtWidgets.QLabel(APP_SUBTITLE)
         untertitel.setObjectName("appSubtitle")
         titel_block.addWidget(titel)
         titel_block.addWidget(untertitel)
@@ -3678,6 +3791,7 @@ class MainWindow(QtWidgets.QMainWindow):
             ["Frequenz", "Status", "Pegel", "Audio", "Letzte Sichtung"]
         )
         richte_tabelle_ein(self.overview_channel_table, stretch_spalte=1)
+        self._markiere_frequenzsortierung(self.overview_channel_table)
         overview_layout.addWidget(self.overview_channel_table, 1)
 
         tab_channels = QtWidgets.QWidget()
@@ -3729,6 +3843,7 @@ class MainWindow(QtWidgets.QMainWindow):
             ["Frequenz", "Pegel", "Status", "Details", "Audio"]
         )
         richte_tabelle_ein(self.signal_search_table, stretch_spalte=3)
+        self._markiere_frequenzsortierung(self.signal_search_table)
         channel_layout.addWidget(self.signal_search_table, 2)
         self.filter_edit = QtWidgets.QLineEdit()
         self.filter_edit.setPlaceholderText("Regex-Filter")
@@ -3985,7 +4100,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.tabs.addTab(tab_overview, "Übersicht")
         self.tabs.addTab(tab_channels, "Kanäle")
         self.tabs.addTab(tab_talkgroups, "Sprechgruppen")
-        self.tabs.addTab(tab_audio_data, "Audio & Daten")
+        self.tabs.addTab(tab_audio_data, "Audio && Daten")
         self.tabs.addTab(tab_network, "Netz")
         self.tabs.addTab(tab_spectrum, "Spektrum")
         self.tabs.addTab(tab_settings, "Einstellungen")
@@ -4273,8 +4388,8 @@ class MainWindow(QtWidgets.QMainWindow):
         v8.addLayout(auswahl_layout)
         v8.addWidget(self.talkgroup_table)
 
-        self.tabs.addTab(tab1, "Spektrum & Steuerung")
-        self.tabs.addTab(tab2, "Audio & Aktivit\u00e4t")
+        self.tabs.addTab(tab1, "Spektrum && Steuerung")
+        self.tabs.addTab(tab2, "Audio && Aktivit\u00e4t")
         self.tabs.addTab(tab3, "Einstellungen")
         self.tabs.addTab(tab4, "TETRA-Dekodierung")
         self.tabs.addTab(tab5, "Zellen")
@@ -4321,6 +4436,62 @@ class MainWindow(QtWidgets.QMainWindow):
         if index < 0:
             index = 0
         self.audio_mode_combo.setCurrentIndex(index)
+
+    def _markiere_frequenzsortierung(self, tabelle):
+        header = tabelle.horizontalHeader()
+        header.setSortIndicatorShown(True)
+        header.setSortIndicator(0, QtCore.Qt.AscendingOrder)
+
+    def _append_plain_text(self, feld, text: str):
+        if feld is None:
+            return
+        leiste = feld.verticalScrollBar()
+        folgen = leiste.value() >= leiste.maximum() - 3
+        feld.appendPlainText(text)
+        if folgen:
+            leiste.setValue(leiste.maximum())
+
+    def _frequenzzeile(self, tabelle, freq: float):
+        key = int(round(freq))
+        for row in range(tabelle.rowCount()):
+            item = tabelle.item(row, 0)
+            if not item:
+                continue
+            wert = item.data(QtCore.Qt.UserRole)
+            if wert is None:
+                continue
+            try:
+                if int(round(float(wert))) == key:
+                    return row
+            except (TypeError, ValueError):
+                continue
+        return None
+
+    def _sortiere_frequenztabelle(self, tabelle, zeilen_map=None):
+        tabelle.setSortingEnabled(True)
+        tabelle.sortItems(0, QtCore.Qt.AscendingOrder)
+        tabelle.setSortingEnabled(False)
+        self._markiere_frequenzsortierung(tabelle)
+        if zeilen_map is not None:
+            zeilen_map.clear()
+            for row in range(tabelle.rowCount()):
+                item = tabelle.item(row, 0)
+                if not item:
+                    continue
+                freq = item.data(QtCore.Qt.UserRole)
+                if freq is not None:
+                    zeilen_map[int(round(float(freq)))] = row
+
+    def _scroll_zeile_sichtbar(self, tabelle, row: int, immer: bool = False):
+        if row is None or row < 0:
+            return
+        item = tabelle.item(row, 0)
+        if not item:
+            return
+        leiste = tabelle.verticalScrollBar()
+        folgen = leiste.value() >= leiste.maximum() - 2
+        if immer or folgen:
+            tabelle.scrollToItem(item, QtWidgets.QAbstractItemView.EnsureVisible)
 
     def _audio_stream_endpoint(self):
         host = "127.0.0.1"
@@ -4461,11 +4632,10 @@ class MainWindow(QtWidgets.QMainWindow):
         if freq <= 0:
             return
         key = int(round(freq))
-        row = self._overview_signal_rows.get(key)
+        row = self._frequenzzeile(self.overview_channel_table, freq)
         if row is None:
             row = self.overview_channel_table.rowCount()
             self.overview_channel_table.insertRow(row)
-            self._overview_signal_rows[key] = row
 
         status = str(info.get("status", ""))
         werte = [
@@ -4482,13 +4652,19 @@ class MainWindow(QtWidgets.QMainWindow):
             farbe = QtGui.QColor("#fff4c4")
         elif status in ("Fehler", "kein TETRA"):
             farbe = QtGui.QColor("#f8d7da")
+        self.overview_channel_table.setSortingEnabled(False)
         for spalte, wert in enumerate(werte):
-            item = QtWidgets.QTableWidgetItem(wert)
+            item = SortierbarerTabellenEintrag(wert)
             if spalte == 0:
                 item.setData(QtCore.Qt.UserRole, freq)
+            elif spalte == 2:
+                item.setData(QtCore.Qt.UserRole, float(info.get("power", 0.0)))
             if farbe is not None:
                 item.setBackground(farbe)
             self.overview_channel_table.setItem(row, spalte, item)
+        self._sortiere_frequenztabelle(self.overview_channel_table, self._overview_signal_rows)
+        row = self._overview_signal_rows.get(key, row)
+        self._scroll_zeile_sichtbar(self.overview_channel_table, row)
         self._refresh_dashboard_status()
 
     def _toggle_monitoring(self, enabled: bool):
@@ -4702,16 +4878,17 @@ class MainWindow(QtWidgets.QMainWindow):
             )[:200]
             self.scan_results = dict(top_items)
 
-        top_peaks = sorted(
+        top_peaks_nach_pegel = sorted(
             self.scan_results.values(),
             key=lambda item: item["power"],
             reverse=True,
         )[:20]
+        top_peaks = sorted(top_peaks_nach_pegel, key=lambda item: item["freq"])
 
         self.freq_list.clear()
         for entry in top_peaks:
             freq_mhz = entry["freq"] / 1e6
-            text = f"{freq_mhz:.3f} MHz \u2013 {entry['power']:.1f} dB"
+            text = f"{freq_mhz:.3f} MHz - {entry['power']:.1f} dB"
             item = QtWidgets.QListWidgetItem(text)
             item.setData(QtCore.Qt.UserRole, entry["freq"])
             self.freq_list.addItem(item)
@@ -4798,7 +4975,8 @@ class MainWindow(QtWidgets.QMainWindow):
             self.audio_status_label.setText(
                 "Audio-Status: keine audiofähige Decoder-Kette verfügbar"
             )
-            self.tetra_output.appendPlainText(
+            self._append_plain_text(
+                self.tetra_output,
                 "Audioausgabe ist nur bei unverschlüsselter Sprache und "
                 "audiofähiger Decoder-Kette möglich."
             )
@@ -4809,7 +4987,8 @@ class MainWindow(QtWidgets.QMainWindow):
             device_text = "ohne Index"
         else:
             device_text = f"Index {device_id}"
-        self.log.appendPlainText(
+        self._append_plain_text(
+            self.log,
             f"Dekodierung gestartet mit Gerät {device_text} ({name}) "
             f"bei {self.current_frequency/1e6:.3f} MHz"
         )
@@ -4855,11 +5034,12 @@ class MainWindow(QtWidgets.QMainWindow):
         self.signal_search_table.setRowCount(0)
         self._signal_search_rows = {}
         self._set_signal_search_buttons(True)
-        self.log.appendPlainText(
+        self._append_plain_text(
+            self.log,
             f"TETRA-Signalsuche gestartet mit Gerät {name}, PPM {self.ppm_spin.value()}, "
             f"Gain {_resolve_gain_value(gain_setting):.1f} dB, {limit_text}."
         )
-        self.tetra_output.appendPlainText("TETRA-Signalsuche gestartet.")
+        self._append_plain_text(self.tetra_output, "TETRA-Signalsuche gestartet.")
 
         worker = TetraSignalSearchWorker(
             ranges=ranges,
@@ -4898,8 +5078,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
     @QtCore.pyqtSlot(str)
     def _append_signal_search_log(self, text: str):
-        self.log.appendPlainText(text)
-        self.tetra_output.appendPlainText(f"[Signalsuche] {text}")
+        self._append_plain_text(self.log, text)
+        self._append_plain_text(self.tetra_output, f"[Signalsuche] {text}")
         logger.info(text)
 
     @QtCore.pyqtSlot(dict)
@@ -4909,11 +5089,10 @@ class MainWindow(QtWidgets.QMainWindow):
         if freq <= 0:
             return
         key = int(round(freq))
-        row = self._signal_search_rows.get(key)
+        row = self._frequenzzeile(self.signal_search_table, freq)
         if row is None:
             row = self.signal_search_table.rowCount()
             self.signal_search_table.insertRow(row)
-            self._signal_search_rows[key] = row
 
         status = str(info.get("status", ""))
         values = [
@@ -4923,10 +5102,13 @@ class MainWindow(QtWidgets.QMainWindow):
             str(info.get("details", "")),
             str(info.get("audio", "")),
         ]
+        self.signal_search_table.setSortingEnabled(False)
         for column, value in enumerate(values):
-            item = QtWidgets.QTableWidgetItem(value)
+            item = SortierbarerTabellenEintrag(value)
             if column == 0:
                 item.setData(QtCore.Qt.UserRole, freq)
+            elif column == 1:
+                item.setData(QtCore.Qt.UserRole, float(info.get("power", 0.0)))
             if status == "bestätigt":
                 item.setBackground(QtGui.QColor("#c8f7c5"))
             elif status in ("unklar", "möglich"):
@@ -4934,11 +5116,13 @@ class MainWindow(QtWidgets.QMainWindow):
             elif status in ("Fehler", "kein TETRA"):
                 item.setBackground(QtGui.QColor("#f5d0d0"))
             self.signal_search_table.setItem(row, column, item)
+        self._sortiere_frequenztabelle(self.signal_search_table, self._signal_search_rows)
+        row = self._signal_search_rows.get(key, row)
 
         lines = info.get("lines") or []
         if lines and status in ("bestätigt", "unklar"):
             for line in lines[:80]:
-                self.tetra_output.appendPlainText(f"[{freq/1e6:.4f} MHz] {line}")
+                self._append_plain_text(self.tetra_output, f"[{freq/1e6:.4f} MHz] {line}")
                 self._append_decoder_data(line)
                 if status == "bestätigt":
                     self.current_frequency = freq
@@ -4950,16 +5134,20 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.freq_label.setText(f"Frequenz: {freq/1e6:.3f} MHz")
                 self.tetra_start_btn.setEnabled(True)
                 self.signal_search_table.selectRow(row)
-                self.log.appendPlainText(
+                self._scroll_zeile_sichtbar(self.signal_search_table, row, immer=True)
+                self._append_plain_text(
+                    self.log,
                     f"TETRA-Signal bestätigt auf {freq/1e6:.4f} MHz."
                 )
+        else:
+            self._scroll_zeile_sichtbar(self.signal_search_table, row)
         self._refresh_dashboard_status()
 
     @QtCore.pyqtSlot()
     def _tetra_signal_search_finished(self):
         self._set_signal_search_buttons(False)
-        self.log.appendPlainText("TETRA-Signalsuche beendet.")
-        self.tetra_output.appendPlainText("TETRA-Signalsuche beendet.")
+        self._append_plain_text(self.log, "TETRA-Signalsuche beendet.")
+        self._append_plain_text(self.tetra_output, "TETRA-Signalsuche beendet.")
         self.tetra_signal_search = None
         if self.monitoring_active:
             delay_ms = int(self.config.get("monitor_cycle_delay_sec", 5)) * 1000
@@ -5052,7 +5240,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     return
             except re.error:
                 pass
-        self.tetra_output.appendPlainText(line)
+        self._append_plain_text(self.tetra_output, line)
         if bool(self.config.get("log_decoder_lines", False)):
             logger.info(line)
         self._append_decoder_data(line)
@@ -5302,6 +5490,8 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.current_frequency is not None:
             freq_text = f"{self.current_frequency/1e6:.4f} MHz"
         typ = _decoder_line_type(line)
+        leiste = self.decoder_data_table.verticalScrollBar()
+        folgen = leiste.value() >= leiste.maximum() - 2
         self.decoder_data.append({
             "zeit": zeit,
             "freq": freq_text,
@@ -5320,7 +5510,8 @@ class MainWindow(QtWidgets.QMainWindow):
             self.decoder_data_table.setItem(row, column, item)
         if self.decoder_data_table.rowCount() > self.decoder_data.maxlen:
             self.decoder_data_table.removeRow(0)
-        self.decoder_data_table.scrollToBottom()
+        if folgen:
+            self.decoder_data_table.scrollToBottom()
 
     def parse_network_info(self, line: str):
         info = _extract_sysinfo(line)

--- a/sdr_gui.py
+++ b/sdr_gui.py
@@ -18,6 +18,7 @@ import pkgutil
 import ctypes.util
 import shlex
 import glob
+import socket
 try:
     import qdarkstyle
 except Exception:
@@ -2495,6 +2496,7 @@ class AudioPlayer(QtCore.QObject):
         self.activity_threshold = 1000
         self.record_file = None
         self.record_last = 0
+        self.record_enabled = False
 
     def start(self, frequency):
         self.stop()
@@ -2599,7 +2601,8 @@ class AudioPlayer(QtCore.QObject):
                         QtCore.QMetaObject.invokeMethod(
                             parent, "notify_activity", QtCore.Qt.QueuedConnection
                         )
-                    self._start_recording()
+                    if self.record_enabled:
+                        self._start_recording()
                 self._write_recording(audio)
                 stream.write(audio.tobytes())
         except Exception as exc:
@@ -2723,6 +2726,103 @@ class DecodedAudioPlayer(QtCore.QObject):
         self._stream.write(data)
         if self._wav:
             self._wav.writeframes(data)
+
+
+class PcmAudioStreamClient(QtCore.QObject):
+    """Empfängt Live-PCM über TCP und reicht die Daten ohne Mitschnitt weiter."""
+
+    audio = QtCore.pyqtSignal(bytes)
+    status = QtCore.pyqtSignal(str)
+    level = QtCore.pyqtSignal(float)
+    stopped = QtCore.pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._thread = None
+        self._running = threading.Event()
+        self._socket = None
+        self._socket_lock = threading.RLock()
+
+    def is_running(self):
+        return self._thread is not None and self._thread.is_alive()
+
+    def start(self, host: str, port: int):
+        if self.is_running():
+            return
+        host = (host or "127.0.0.1").strip()
+        port = int(port)
+        self._running.set()
+        self._thread = threading.Thread(
+            target=self._run,
+            args=(host, port),
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self):
+        self._running.clear()
+        with self._socket_lock:
+            sock = self._socket
+            self._socket = None
+        if sock:
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                sock.close()
+            except OSError:
+                pass
+        if (
+            self._thread
+            and self._thread.is_alive()
+            and threading.current_thread() is not self._thread
+        ):
+            self._thread.join(timeout=2)
+        if not self.is_running():
+            self._thread = None
+
+    def _run(self, host: str, port: int):
+        rest = b""
+        try:
+            self.status.emit(f"Stream verbindet zu {host}:{port}")
+            with socket.create_connection((host, port), timeout=4) as sock:
+                sock.settimeout(0.5)
+                with self._socket_lock:
+                    self._socket = sock
+                self.status.emit(f"Stream verbunden: {host}:{port}")
+                while self._running.is_set():
+                    try:
+                        chunk = sock.recv(4096)
+                    except socket.timeout:
+                        continue
+                    if not chunk:
+                        self.status.emit("Stream beendet")
+                        break
+                    data = rest + chunk
+                    if len(data) % 2:
+                        rest = data[-1:]
+                        data = data[:-1]
+                    else:
+                        rest = b""
+                    if not data:
+                        continue
+                    self.audio.emit(data)
+                    try:
+                        werte = np.frombuffer(data, dtype=np.int16).astype(np.int32)
+                        if werte.size:
+                            pegel = min(1.0, float(np.max(np.abs(werte))) / 32768.0)
+                            self.level.emit(pegel)
+                    except Exception:
+                        pass
+        except Exception as exc:
+            if self._running.is_set():
+                self.status.emit(f"Stream nicht verbunden: {exc}")
+        finally:
+            self._running.clear()
+            with self._socket_lock:
+                self._socket = None
+            self.stopped.emit()
 
 
 class TetraDecoder(QtCore.QObject):
@@ -3221,13 +3321,21 @@ class MainWindow(QtWidgets.QMainWindow):
             "tetra_max_candidates": 0,
             "audio_mode": "safe",
             "record_audio": False,
+            "audio_stream_host": "127.0.0.1",
+            "audio_stream_port": 7355,
+            "log_decoder_lines": False,
             "monitor_cycle_delay_sec": 5,
-            "ui_profile_version": 2,
+            "ui_profile_version": 3,
         }
         self.config.update(load_config())
-        if int(self.config.get("ui_profile_version", 0) or 0) < 2:
+        profil_version = int(self.config.get("ui_profile_version", 0) or 0)
+        if profil_version < 2:
             self.config["calibrate_on_start"] = True
             self.config["ui_profile_version"] = 2
+        if profil_version < 3:
+            self.config["record_audio"] = False
+            self.config["log_decoder_lines"] = False
+            self.config["ui_profile_version"] = 3
         if abs(float(self.config.get("calibration_ref_mhz", 99.2)) - 421.0375) < 0.0001:
             self.config["calibration_ref_mhz"] = 99.2
         if int(self.config.get("calibration_search_khz", 180)) == 100:
@@ -3278,6 +3386,8 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         self.decoder = TetraDecoder(ppm=self.config.get("ppm", 0), parent=self)
         self.dec_audio_player = DecodedAudioPlayer(parent=self)
+        self.stream_audio_player = DecodedAudioPlayer(parent=self)
+        self.audio_stream_client = PcmAudioStreamClient(parent=self)
 
         self.scheduler_timer = QtCore.QTimer(self)
         self.scheduler_timer.timeout.connect(self.run_scheduled_cycle)
@@ -3319,6 +3429,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.decoder.finished.connect(self._decoder_finished)
         self.decoder.audio.connect(self.dec_audio_player.process)
         self.decoder.encrypted.connect(self._encrypted_signal)
+        self.audio_stream_client.audio.connect(self.stream_audio_player.process)
+        self.audio_stream_client.status.connect(self._stream_status)
+        self.audio_stream_client.level.connect(self._stream_level)
+        self.audio_stream_client.stopped.connect(self._stream_stopped)
 
         self.tetra_start_btn.clicked.connect(self.start_decoding)
         self.tetra_stop_btn.clicked.connect(self.stop_decoding)
@@ -3342,6 +3456,17 @@ class MainWindow(QtWidgets.QMainWindow):
         self.play_audio_cb.toggled.connect(self._toggle_dec_audio)
         self.record_audio_cb.toggled.connect(
             lambda checked: self.config.__setitem__("record_audio", bool(checked))
+        )
+        self.audio_stream_start_btn.clicked.connect(self.start_audio_stream)
+        self.audio_stream_stop_btn.clicked.connect(self.stop_audio_stream)
+        self.audio_stream_host_edit.textChanged.connect(
+            lambda text: self.config.__setitem__("audio_stream_host", text.strip())
+        )
+        self.audio_stream_port_spin.valueChanged.connect(
+            lambda value: self.config.__setitem__("audio_stream_port", int(value))
+        )
+        self.log_decoder_lines_cb.toggled.connect(
+            lambda checked: self.config.__setitem__("log_decoder_lines", bool(checked))
         )
 
         self.theme_combo.currentIndexChanged.connect(self._on_theme_change)
@@ -3661,6 +3786,34 @@ class MainWindow(QtWidgets.QMainWindow):
         audio_bar.addWidget(self.audio_status_label)
         audio_data_layout.addLayout(audio_bar)
 
+        stream_bar = QtWidgets.QHBoxLayout()
+        stream_bar.addWidget(QtWidgets.QLabel("Live-Stream:"))
+        self.audio_stream_host_edit = QtWidgets.QLineEdit(
+            str(self.config.get("audio_stream_host", "127.0.0.1"))
+        )
+        self.audio_stream_host_edit.setFixedWidth(130)
+        stream_bar.addWidget(self.audio_stream_host_edit)
+        self.audio_stream_port_spin = QtWidgets.QSpinBox()
+        self.audio_stream_port_spin.setRange(1, 65535)
+        self.audio_stream_port_spin.setValue(int(self.config.get("audio_stream_port", 7355)))
+        stream_bar.addWidget(self.audio_stream_port_spin)
+        self.audio_stream_start_btn = aktionsknopf(
+            "Stream starten",
+            QtWidgets.QStyle.SP_MediaPlay,
+            primaer=True,
+        )
+        self.audio_stream_stop_btn = aktionsknopf("Stream stoppen", QtWidgets.QStyle.SP_MediaStop)
+        self.audio_stream_stop_btn.setEnabled(False)
+        stream_bar.addWidget(self.audio_stream_start_btn)
+        stream_bar.addWidget(self.audio_stream_stop_btn)
+        self.audio_stream_status_label = QtWidgets.QLabel(
+            "PCM 16 Bit, mono, 8000 Hz, ohne Mitschnitt"
+        )
+        self.audio_stream_status_label.setObjectName("statusDetail")
+        stream_bar.addWidget(self.audio_stream_status_label)
+        stream_bar.addStretch()
+        audio_data_layout.addLayout(stream_bar)
+
         self.decoder_data_table = QtWidgets.QTableWidget(0, 4)
         self.decoder_data_table.setHorizontalHeaderLabels(
             ["Zeit", "Frequenz", "Typ", "Inhalt"]
@@ -3787,6 +3940,14 @@ class MainWindow(QtWidgets.QMainWindow):
         agc_layout.addWidget(self.agc_slider)
         agc_layout.addWidget(self.agc_value)
         f_rechts.addRow("Audio-AGC-Ziel:", agc_layout)
+
+        self.log_decoder_lines_cb = QtWidgets.QCheckBox(
+            "vollständige Decoderzeilen in tetra.log schreiben"
+        )
+        self.log_decoder_lines_cb.setChecked(
+            bool(self.config.get("log_decoder_lines", False))
+        )
+        f_rechts.addRow("Datei-Logging:", self.log_decoder_lines_cb)
 
         self.theme_combo = QtWidgets.QComboBox()
         self.theme_combo.addItem("Hell", "light")
@@ -4161,6 +4322,73 @@ class MainWindow(QtWidgets.QMainWindow):
             index = 0
         self.audio_mode_combo.setCurrentIndex(index)
 
+    def _audio_stream_endpoint(self):
+        host = "127.0.0.1"
+        port = 7355
+        if hasattr(self, "audio_stream_host_edit"):
+            host = self.audio_stream_host_edit.text().strip() or host
+        else:
+            host = str(self.config.get("audio_stream_host", host)).strip() or host
+        if hasattr(self, "audio_stream_port_spin"):
+            port = int(self.audio_stream_port_spin.value())
+        else:
+            port = int(self.config.get("audio_stream_port", port))
+        return host, port
+
+    def start_audio_stream(self):
+        """Startet den Live-PCM-Eingang ohne automatische Dateiausgabe."""
+        host, port = self._audio_stream_endpoint()
+        self.config["audio_stream_host"] = host
+        self.config["audio_stream_port"] = int(port)
+        record = bool(self.record_audio_cb.isChecked())
+        self.stream_audio_player.start(record=record)
+        self.audio_stream_start_btn.setEnabled(False)
+        self.audio_stream_stop_btn.setEnabled(True)
+        self.audio_stream_status_label.setText(f"Verbinde {host}:{port}")
+        self.audio_status_label.setText("Audio-Status: Stream verbindet")
+        self.audio_stream_client.start(host, port)
+        self._refresh_dashboard_status()
+
+    def stop_audio_stream(self):
+        """Stoppt den Live-PCM-Eingang."""
+        lief = bool(
+            hasattr(self, "audio_stream_client")
+            and self.audio_stream_client.is_running()
+        )
+        if hasattr(self, "audio_stream_client"):
+            self.audio_stream_client.stop()
+        if hasattr(self, "stream_audio_player"):
+            self.stream_audio_player.stop()
+        if hasattr(self, "audio_stream_start_btn"):
+            self.audio_stream_start_btn.setEnabled(True)
+            self.audio_stream_stop_btn.setEnabled(False)
+        if lief and hasattr(self, "audio_stream_status_label"):
+            self.audio_stream_status_label.setText("Stream gestoppt")
+        if lief and hasattr(self, "audio_status_label"):
+            self.audio_status_label.setText("Audio-Status: Stream gestoppt")
+        self._refresh_dashboard_status()
+
+    @QtCore.pyqtSlot(str)
+    def _stream_status(self, text: str):
+        if hasattr(self, "audio_stream_status_label"):
+            self.audio_stream_status_label.setText(text)
+        if hasattr(self, "audio_status_label"):
+            self.audio_status_label.setText(f"Audio-Status: {text}")
+        self._refresh_dashboard_status()
+
+    @QtCore.pyqtSlot(float)
+    def _stream_level(self, level: float):
+        if level > 0.05:
+            self.activity_led.set_color("yellow")
+            QtCore.QTimer.singleShot(300, lambda: self.activity_led.set_color("green"))
+
+    @QtCore.pyqtSlot()
+    def _stream_stopped(self):
+        self.stream_audio_player.stop()
+        self.audio_stream_start_btn.setEnabled(True)
+        self.audio_stream_stop_btn.setEnabled(False)
+        self._refresh_dashboard_status()
+
     def _refresh_dashboard_status(self):
         if not hasattr(self, "dashboard_device_value"):
             return
@@ -4210,7 +4438,11 @@ class MainWindow(QtWidgets.QMainWindow):
 
         status = self.audio_status_label.text().replace("Audio-Status:", "").strip()
         self.dashboard_audio_value.setText(status or "wartet")
-        self.dashboard_audio_detail.setText(f"Modus: {self._audio_mode_text()}")
+        if hasattr(self, "audio_stream_client") and self.audio_stream_client.is_running():
+            host, port = self._audio_stream_endpoint()
+            self.dashboard_audio_detail.setText(f"Stream {host}:{port}")
+        else:
+            self.dashboard_audio_detail.setText(f"Modus: {self._audio_mode_text()}")
 
         talkgroups = getattr(self, "talkgroups", {})
         selected_talkgroups = getattr(self, "selected_talkgroups", set())
@@ -4821,7 +5053,8 @@ class MainWindow(QtWidgets.QMainWindow):
             except re.error:
                 pass
         self.tetra_output.appendPlainText(line)
-        logger.info(line)
+        if bool(self.config.get("log_decoder_lines", False)):
+            logger.info(line)
         self._append_decoder_data(line)
         if line.startswith("Audioausgabe:"):
             self.audio_status_label.setText(f"Audio-Status: {line.split(':', 1)[1].strip()}")
@@ -4874,6 +5107,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.scanner.stop()
         self.player.stop()
         self.stop_decoding()
+        self.stop_audio_stream()
         self._refresh_dashboard_status()
 
     def closeEvent(self, event):
@@ -4896,7 +5130,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.config["calibrate_on_start"] = bool(self.calibrate_on_start_cb.isChecked())
         self.config["audio_mode"] = self._audio_mode()
         self.config["record_audio"] = bool(self.record_audio_cb.isChecked())
-        self.config["ui_profile_version"] = 2
+        host, port = self._audio_stream_endpoint()
+        self.config["audio_stream_host"] = host
+        self.config["audio_stream_port"] = int(port)
+        self.config["log_decoder_lines"] = bool(self.log_decoder_lines_cb.isChecked())
+        self.config["ui_profile_version"] = 3
         self.config["tetra_probe_all_candidates"] = bool(
             self.probe_all_candidates_cb.isChecked()
         )

--- a/sdr_gui.py
+++ b/sdr_gui.py
@@ -485,6 +485,7 @@ TETRA_DEFAULT_RANGES = [
     ("440-443 MHz (Bündelfunk Unterband)", 440e6, 443e6),
     ("445-448 MHz (Bündelfunk Oberband/Basis)", 445e6, 448e6),
 ]
+TETRA_ALL_RANGES_LABEL = "Alle Bereiche"
 TETRA_SCAN_BIN_HZ = 12_500
 TETRA_CHANNEL_RASTER_HZ = 12_500
 
@@ -649,6 +650,31 @@ def _decoder_line_type(line: str):
     if "Keine gültigen TETRA-Bursts" in line or "Zu wenige Demodulationsbits" in line:
         return "Status"
     return "Rohdaten"
+
+
+def _decoder_line_for_ui(line: str) -> bool:
+    text = line.strip()
+    if not text:
+        return False
+    if text.startswith("Audioausgabe:"):
+        return True
+    if text.startswith(("Keine ", "Zu wenige ", "Windows-TETRA-", "Nutze ")):
+        return True
+    if "BNCH SYSINFO" in text or "SYSINFO PDU" in text:
+        return True
+    if "ACCESS-ASSIGN PDU" in text and "Traffic" in text:
+        return True
+    if "RESOURCE" in text and "Addr=Null" not in text:
+        return True
+    if re.search(
+        r"\b(?:D-|U-|SDS|LOCATION|AUTHENTICATION|ATTACH|DETACH|CALL|CONNECT|DISCONNECT)\b",
+        text,
+        re.I,
+    ):
+        return True
+    if extract_talkgroup_ids(text):
+        return True
+    return False
 
 
 def _extract_sysinfo(line: str):
@@ -3579,6 +3605,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.canvas = SpectrumCanvas()
         self.log = QtWidgets.QPlainTextEdit()
         self.log.setReadOnly(True)
+        self.log.setLineWrapMode(QtWidgets.QPlainTextEdit.WidgetWidth)
+        self.log.setWordWrapMode(QtGui.QTextOption.WrapAtWordBoundaryOrAnywhere)
         self.freq_list = QtWidgets.QListWidget()
 
         self.activity_led = LEDIndicator()
@@ -3587,8 +3615,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.refresh_devices()
 
         self.freq_range_box = QtWidgets.QComboBox()
+        self.freq_range_box.addItem(TETRA_ALL_RANGES_LABEL, None)
         for label, start_hz, end_hz in TETRA_DEFAULT_RANGES:
             self.freq_range_box.addItem(label, (start_hz, end_hz))
+        self.freq_range_box.setMinimumContentsLength(28)
 
         self.agc_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
         self.agc_slider.setRange(5000, 20000)
@@ -3686,6 +3716,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.stream_audio_player = DecodedAudioPlayer(parent=self)
         self.audio_stream_client = PcmAudioStreamClient(parent=self)
         self._stream_record_requested = False
+        self._encrypted_notice_shown = False
 
         self.scheduler_timer = QtCore.QTimer(self)
         self.scheduler_timer.timeout.connect(self.run_scheduled_cycle)
@@ -3874,7 +3905,8 @@ class MainWindow(QtWidgets.QMainWindow):
             tabelle.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
             tabelle.verticalHeader().setVisible(False)
             tabelle.setShowGrid(False)
-            tabelle.setWordWrap(False)
+            tabelle.setWordWrap(True)
+            tabelle.verticalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
             tabelle.horizontalHeader().setHighlightSections(False)
             if stretch_spalte is not None:
                 for spalte in range(tabelle.columnCount()):
@@ -4012,6 +4044,8 @@ class MainWindow(QtWidgets.QMainWindow):
         channel_layout.addLayout(kanal_toolbar)
 
         suchoptionen_layout = QtWidgets.QHBoxLayout()
+        suchoptionen_layout.addWidget(QtWidgets.QLabel("Bereich:"))
+        suchoptionen_layout.addWidget(self.freq_range_box, 1)
         self.probe_all_candidates_cb = QtWidgets.QCheckBox("Alle gefundenen Kandidaten prüfen")
         self.probe_all_candidates_cb.setChecked(
             bool(self.config.get("tetra_probe_all_candidates", True))
@@ -4040,6 +4074,8 @@ class MainWindow(QtWidgets.QMainWindow):
         channel_layout.addWidget(self.filter_edit)
         self.tetra_output = QtWidgets.QPlainTextEdit()
         self.tetra_output.setReadOnly(True)
+        self.tetra_output.setLineWrapMode(QtWidgets.QPlainTextEdit.WidgetWidth)
+        self.tetra_output.setWordWrapMode(QtGui.QTextOption.WrapAtWordBoundaryOrAnywhere)
         self.tetra_output.setMaximumBlockCount(2000)
         channel_layout.addWidget(self.tetra_output, 1)
 
@@ -4095,6 +4131,8 @@ class MainWindow(QtWidgets.QMainWindow):
         audio_bar.addStretch()
         self.audio_status_label = QtWidgets.QLabel("Audio-Status: wartet")
         self.audio_status_label.setObjectName("audioStatus")
+        self.audio_status_label.setWordWrap(True)
+        self.audio_status_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
         audio_bar.addWidget(self.audio_status_label)
         audio_data_layout.addLayout(audio_bar)
 
@@ -4122,6 +4160,7 @@ class MainWindow(QtWidgets.QMainWindow):
             "PCM 16 Bit, mono, 8000 Hz, ohne Mitschnitt"
         )
         self.audio_stream_status_label.setObjectName("statusDetail")
+        self.audio_stream_status_label.setWordWrap(True)
         self.audio_stream_status_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
         stream_bar.addWidget(self.audio_stream_status_label)
         stream_bar.addStretch()
@@ -4193,7 +4232,6 @@ class MainWindow(QtWidgets.QMainWindow):
         refresh.clicked.connect(self.refresh_devices)
         dev_layout.addWidget(refresh)
         f_links.addRow("Gerät:", dev_layout)
-        f_links.addRow("Frequenzbereich:", self.freq_range_box)
         self.ppm_spin = QtWidgets.QSpinBox()
         self.ppm_spin.setRange(-100, 100)
         self.ppm_spin.setValue(self.config.get("ppm", 0))
@@ -4229,6 +4267,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.calibration_status_label = QtWidgets.QLabel(
             "Referenz: WDR 2 Essen 99,200 MHz"
         )
+        self.calibration_status_label.setWordWrap(True)
+        self.calibration_status_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
         start_cal_layout = QtWidgets.QHBoxLayout()
         start_cal_layout.addWidget(self.calibrate_on_start_cb)
         start_cal_layout.addWidget(self.calibration_status_label)
@@ -4649,6 +4689,32 @@ class MainWindow(QtWidgets.QMainWindow):
         if folgen:
             leiste.setValue(leiste.maximum())
 
+    def _ausgewaehlte_tetra_bereiche(self):
+        daten = self.freq_range_box.currentData()
+        if isinstance(daten, (tuple, list)) and len(daten) == 2:
+            return [(self.freq_range_box.currentText(), float(daten[0]), float(daten[1]))]
+        return list(TETRA_DEFAULT_RANGES)
+
+    def _bereichs_text(self):
+        bereiche = self._ausgewaehlte_tetra_bereiche()
+        if len(bereiche) == 1:
+            return bereiche[0][0]
+        return TETRA_ALL_RANGES_LABEL
+
+    def _tabellentext(self, text, limit: int = 180):
+        text = str(text)
+        if len(text) <= limit:
+            return text
+        return text[: max(0, limit - 3)].rstrip() + "..."
+
+    def _tabellen_item(self, text, limit: int | None = None):
+        volltext = str(text)
+        anzeige = self._tabellentext(volltext, limit) if limit else volltext
+        item = SortierbarerTabellenEintrag(anzeige)
+        if anzeige != volltext:
+            item.setToolTip(volltext)
+        return item
+
     def _frequenzzeile(self, tabelle, freq: float):
         key = int(round(freq))
         for row in range(tabelle.rowCount()):
@@ -4816,7 +4882,7 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             scan_text = "gestoppt"
         self.dashboard_scan_value.setText(scan_text)
-        self.dashboard_scan_detail.setText(self.freq_range_box.currentText())
+        self.dashboard_scan_detail.setText(self._bereichs_text())
 
         bestaetigt = 0
         if hasattr(self, "overview_channel_table"):
@@ -4877,7 +4943,7 @@ class MainWindow(QtWidgets.QMainWindow):
             farbe = QtGui.QColor("#f8d7da")
         self.overview_channel_table.setSortingEnabled(False)
         for spalte, wert in enumerate(werte):
-            item = SortierbarerTabellenEintrag(wert)
+            item = self._tabellen_item(wert, limit=90)
             if spalte == 0:
                 item.setData(QtCore.Qt.UserRole, freq)
             elif spalte == 2:
@@ -5225,6 +5291,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.tetra_start_btn.setEnabled(False)
         self.tetra_stop_btn.setEnabled(True)
         self.tetra_output.clear()
+        self._encrypted_notice_shown = False
         rec = self.record_audio_cb.isChecked()
         audio_mode = self._audio_mode()
         audio_requested = audio_mode != "off" and self.play_audio_cb.isChecked()
@@ -5280,14 +5347,8 @@ class MainWindow(QtWidgets.QMainWindow):
         gain_setting = _normalize_gain_setting(self.config.get("gain", "max"))
         self.config["gain"] = gain_setting
 
-        ranges = []
-        for index in range(self.freq_range_box.count()):
-            data = self.freq_range_box.itemData(index)
-            if not data:
-                continue
-            ranges.append((self.freq_range_box.itemText(index), data[0], data[1]))
-        if not ranges:
-            ranges = TETRA_DEFAULT_RANGES
+        ranges = self._ausgewaehlte_tetra_bereiche()
+        range_text = self._bereichs_text()
 
         if self.probe_all_candidates_cb.isChecked():
             max_candidates = None
@@ -5302,7 +5363,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self._append_plain_text(
             self.log,
             f"TETRA-Signalsuche gestartet mit Gerät {name}, PPM {self.ppm_spin.value()}, "
-            f"Gain {_resolve_gain_value(gain_setting):.1f} dB, {limit_text}."
+            f"Gain {_resolve_gain_value(gain_setting):.1f} dB, Bereich {range_text}, "
+            f"{limit_text}."
         )
         self._append_plain_text(self.tetra_output, "TETRA-Signalsuche gestartet.")
 
@@ -5329,7 +5391,15 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         worker.stop()
         if wait:
-            worker.wait(2000)
+            if not worker.wait(12000):
+                text = "TETRA-Signalsuche reagierte nicht rechtzeitig und wird hart beendet."
+                logger.warning(text)
+                try:
+                    self._append_plain_text(self.log, text)
+                except RuntimeError:
+                    pass
+                worker.terminate()
+                worker.wait(3000)
         self._set_signal_search_buttons(False)
 
     def _set_signal_search_buttons(self, running: bool):
@@ -5369,7 +5439,8 @@ class MainWindow(QtWidgets.QMainWindow):
         ]
         self.signal_search_table.setSortingEnabled(False)
         for column, value in enumerate(values):
-            item = SortierbarerTabellenEintrag(value)
+            limit = 180 if column == 3 else 80
+            item = self._tabellen_item(value, limit=limit)
             if column == 0:
                 item.setData(QtCore.Qt.UserRole, freq)
             elif column == 1:
@@ -5492,8 +5563,17 @@ class MainWindow(QtWidgets.QMainWindow):
     def _encrypted_signal(self):
         self.dec_audio_player.stop()
         self.audio_status_label.setText("Audio-Status: Signal verschlüsselt")
+        self.audio_status_label.setToolTip(
+            "Der Kanal signalisiert Luftschnittstellen-Verschlüsselung; "
+            "Audio wird deshalb nicht ausgegeben."
+        )
+        if not self._encrypted_notice_shown:
+            self._encrypted_notice_shown = True
+            self._append_plain_text(
+                self.log,
+                "Verschlüsseltes TETRA-Signal erkannt; Audioausgabe bleibt aus.",
+            )
         self._refresh_dashboard_status()
-        QtWidgets.QMessageBox.information(self, "Info", "Verschl\u00fcsseltes Signal erkannt")
 
     def _append_tetra(self, line: str):
         if not self._line_matches_selected_talkgroup(line):
@@ -5505,10 +5585,14 @@ class MainWindow(QtWidgets.QMainWindow):
                     return
             except re.error:
                 pass
-        self._append_plain_text(self.tetra_output, line)
-        if bool(self.config.get("log_decoder_lines", False)):
+        vollstaendig = bool(self.config.get("log_decoder_lines", False))
+        sichtbar = vollstaendig or _decoder_line_for_ui(line)
+        if sichtbar:
+            self._append_plain_text(self.tetra_output, line)
+        if vollstaendig:
             logger.info(line)
-        self._append_decoder_data(line)
+        if sichtbar:
+            self._append_decoder_data(line)
         if line.startswith("Audioausgabe:"):
             self.audio_status_label.setText(f"Audio-Status: {line.split(':', 1)[1].strip()}")
             self._refresh_dashboard_status()
@@ -5539,24 +5623,25 @@ class MainWindow(QtWidgets.QMainWindow):
         self.decoder.gain = gain_setting
         self.decoder.device_id = device_id
         self._update_ppm(self.ppm_spin.value())
-        rng = self.freq_range_box.currentData()
-        f_start, f_end = rng if rng else (380e6, 430e6)
+        bereiche = self._ausgewaehlte_tetra_bereiche()
+        f_start = min(start for _label, start, _end in bereiche)
+        f_end = max(end for _label, _start, end in bereiche)
         if device_id is None:
             device_text = "ohne Index"
         else:
             device_text = f"Index {device_id}"
         self.log.appendPlainText(
             f"Scan gestartet mit Gerät {device_text} ({name}) "
-            f"({f_start/1e6:.0f}-{f_end/1e6:.0f} MHz)"
+            f"({self._bereichs_text()}, {f_start/1e6:.0f}-{f_end/1e6:.0f} MHz)"
         )
         self.scanner.start(f_start, f_end)
         self._refresh_dashboard_status()
 
-    def stop(self):
+    def stop(self, wait=False):
         self.log.appendPlainText("Stoppe")
         self.stop_monitoring()
-        self.stop_calibration(wait=True)
-        self.stop_tetra_signal_search(wait=True)
+        self.stop_calibration(wait=wait)
+        self.stop_tetra_signal_search(wait=wait)
         self.scanner.stop()
         self.player.stop()
         self.stop_decoding()
@@ -5565,7 +5650,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def closeEvent(self, event):
         self._closing = True
-        self.stop()
+        self.stop(wait=True)
         self._store_current_settings()
         self._persist_talkgroups_to_config()
         self._persist_selected_talkgroups_to_config()
@@ -5766,7 +5851,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.decoder_data_table.insertRow(row)
         werte = [zeit, freq_text, typ, line]
         for column, value in enumerate(werte):
-            item = QtWidgets.QTableWidgetItem(value)
+            item = self._tabellen_item(value, limit=220 if column == 3 else 80)
             if typ in ("CRC OK", "Netzinfo"):
                 item.setBackground(QtGui.QColor("#c8f7c5"))
             elif typ in ("Verschlüsselung", "Status"):

--- a/windows-offline-installer.nsi
+++ b/windows-offline-installer.nsi
@@ -65,6 +65,9 @@ Section "Programmdateien" SEC_APP
   SetOutPath "$INSTDIR\scripts"
   File /r "scripts\*"
 
+  SetOutPath "$INSTDIR\patches"
+  File /r "patches\*"
+
   SetOutPath "$INSTDIR\third_party\osmo-tetra"
   File /r /x ".git" "third_party\osmo-tetra\*"
 


### PR DESCRIPTION
## Inhalt
- Live-PCM-Stream-Eingang per TCP fuer externe TETRA-Voice-Decoder ergaenzt
- Standardformat: PCM 16 Bit, mono, 8000 Hz auf konfigurierbarem Host/Port
- Decoder-Dateilogging standardmaessig deaktiviert, um tetra.log klein zu halten
- Unerwartete automatische WAV-Mitschnitte der Audioaktivitaet standardmaessig verhindert

## Tests
- python -m py_compile sdr_gui.py
- lokaler PCM-Teststream mit PcmAudioStreamClient
- Offscreen-Start von MainWindow mit Defaults: Aufnahme aus, Decoder-Dateilogging aus
- python -m PyInstaller --clean -y tetra-decode.spec